### PR TITLE
Vehicle repair/remove part fix

### DIFF
--- a/ModSource/breakingpoint_functions/functions/Vehicle/fn_vehicleHandleRemove.sqf
+++ b/ModSource/breakingpoint_functions/functions/Vehicle/fn_vehicleHandleRemove.sqf
@@ -7,7 +7,7 @@
 	Alderon Games Pty Ltd
 */
 
-params ["_vehicle","_hitpoint","_damage"];
+params ["_vehicle","_hitpoint","_damage","_hitpoints"];
 
 // Valid Vehicle
 if (isNull _vehicle) exitWith {};
@@ -15,12 +15,11 @@ if (isNull _vehicle) exitWith {};
 // Repairing doesn't work on remote vehicles
 if (!local _vehicle) exitWith {};
 
+// Set Hit Points Damage Values Back
+{ _vehicle setHitPointDamage [(_x select 0),(_x select 1)]; } count _hitpoints;
+
 // Repair HitPoint
 _vehicle setHitPointDamage [_hitpoint,_damage];
-
-// Set Hit Points Damage Values Back
-_hitpoints = _vehicle call BP_fnc_vehicleHitpointsDmg;
-{ _vehicle setHitPointDamage [(_x select 0),(_x select 1)]; } count _hitpoints;
 
 // Bump Vehicle to Sync It Over Network
 _vehicle setVelocity [0,0,1];

--- a/ModSource/breakingpoint_functions/functions/Vehicle/fn_vehicleHandleRepair.sqf
+++ b/ModSource/breakingpoint_functions/functions/Vehicle/fn_vehicleHandleRepair.sqf
@@ -7,7 +7,7 @@
 	Alderon Games Pty Ltd
 */
 
-params ["_vehicle","_hitpoint","_damage"];
+params ["_vehicle","_hitpoint","_damage","_hitpoints"];
 
 ["vehicleHandleRepair: Vehicle: %1 | Hitpoint: %2 | Damage: %3",_vehicle,_hitpoint,_damage] call BP_fnc_debugConsoleFormat;
 
@@ -17,12 +17,11 @@ if (isNull _vehicle) exitWith {};
 // Repairing doesn't work on remote vehicles
 if (!local _vehicle) exitWith {};
 
+// Set Hit Points Damage Values Back
+{ _vehicle setHitPointDamage [(_x select 0),(_x select 1)]; } count _hitpoints;
+
 // Repair HitPoint
 _vehicle setHitPointDamage [_hitpoint,_damage];
-
-// Set Hit Points Damage Values Back
-_hitpoints = _vehicle call BP_fnc_vehicleHitpointsDmg;
-{ _vehicle setHitPointDamage [(_x select 0),(_x select 1)]; } count _hitpoints;
 
 // Bump Vehicle to Sync It Over Network
 _vehicle setVelocity [0,0,1];

--- a/ModSource/breakingpoint_server/functions/Vehicle/fn_vehicleRemove.sqf
+++ b/ModSource/breakingpoint_server/functions/Vehicle/fn_vehicleRemove.sqf
@@ -40,9 +40,9 @@ _vehicle setDamage _totalDamage;
 // Handle Locality Specific Repair
 if (local _vehicle) then
 {
-	[_vehicle,_hitpoint,_damage] call BP_fnc_vehicleHandleRemove;
+	[_vehicle,_hitpoint,_damage,_hitpoints] call BP_fnc_vehicleHandleRemove;
 } else {
-	[_vehicle,_hitpoint,_damage] remoteExecCall ["BP_fnc_vehicleHandleRemove", _vehicle];
+	[_vehicle,_hitpoint,_damage,_hitpoints] remoteExecCall ["BP_fnc_vehicleHandleRemove", _vehicle];
 };
 
 // Create Removed Part

--- a/ModSource/breakingpoint_server/functions/Vehicle/fn_vehicleRepair.sqf
+++ b/ModSource/breakingpoint_server/functions/Vehicle/fn_vehicleRepair.sqf
@@ -48,9 +48,9 @@ _vehicle setDamage _totalDamage;
 // Handle Locality Specific Repair
 if (local _vehicle) then
 {
-	[_vehicle,_hitpoint,_damage] call BP_fnc_vehicleHandleRepair;
+	[_vehicle,_hitpoint,_damage,_hitpoints] call BP_fnc_vehicleHandleRepair;
 } else {
-	[_vehicle,_hitpoint,_damage] remoteExecCall ["BP_fnc_vehicleHandleRepair", _vehicle];
+	[_vehicle,_hitpoint,_damage,_hitpoints] remoteExecCall ["BP_fnc_vehicleHandleRepair", _vehicle];
 };
 
 // Add Vehicle To Update Queue


### PR DESCRIPTION
Vehicle repair/remove part fix

changed serverside that the old hitpoints damage values are commited to the clients fn_vehicleRepair/Remove.sqf

changed clientside: the old hitpoints damage values are applied afterwards the setDamage command is executed and after that the part to rapair/remove gets repaiered or removed