### PR TITLE
Changed rcon port

### DIFF
--- a/ServerConfiguration/ServerConfig/BreakingPointExt.ini
+++ b/ServerConfiguration/ServerConfig/BreakingPointExt.ini
@@ -14,7 +14,7 @@ slots = 100
 reserved = 10
 
 [RCON]
-port = 2305
+port = 2306
 password = changeme
 whitelist = false
 


### PR DESCRIPTION
arma uses 2302 to 2305 so 2306 should be free for rcon
check Port Forwarding => https://community.bistudio.com/wiki/Arma_3_Dedicated_Server