### PR TITLE
Tweaked hostage system to hold kidnapper responsible for hostage's well-being

### DIFF
--- a/ModSource/breakingpoint_server/functions/Actions/fn_hostageAdd.sqf
+++ b/ModSource/breakingpoint_server/functions/Actions/fn_hostageAdd.sqf
@@ -24,6 +24,7 @@ if (!alive _player) exitWith {};
 if (!alive _hostage) exitWith {};
 
 _hostage setVariable ["med_hostage",true,true];
+_hostage setVariable ["hostage_perpetrator", _playerNetID, true];
 
 BP_HostageAdd = [_playerNetID,_hostageNetID];
 (owner _hostage) publicVariableClient "BP_HostageAdd";

--- a/ModSource/breakingpoint_server/functions/Events/fn_medicalUpdate.sqf
+++ b/ModSource/breakingpoint_server/functions/Events/fn_medicalUpdate.sqf
@@ -13,6 +13,13 @@ params ["_event","_unitNetID","_medicEventID"];
 
 _unit = objectFromNetID _unitNetID;
 _medic = objectFromNetID _medicEventID;
+_isHostage = _unit getVariable ["med_hostage", false];
+_perpetrator = _unit getVariable ["hostage_perpetrator", "0"];
+
+if (_isHostage && _perpetrator != "0" && _event == "medGut") then
+{
+	_medic = objectFromNetID _perpetrator;
+};
 
 if (isNull _unit) exitWith {};
 if (isNull _medic) exitWith {};

--- a/ModSource/breakingpoint_server/functions/Events/fn_playerDeath.sqf
+++ b/ModSource/breakingpoint_server/functions/Events/fn_playerDeath.sqf
@@ -16,6 +16,23 @@ params [["_characterID","0",[""]],"_playerNetID",["_playerID","",[""]],["_player
 // Resolve Player & Killer Objects from Net ID's
 _player = (objectFromNetID _playerNetID);
 _killer = (objectFromNetID _killerNetID);
+_isHostage = _player getVariable ["med_hostage", false];
+_perpetrator = _player getVariable ["hostage_perpetrator", "0"];
+_isHostageKill = (_player != _killer && _isHostage && _perpetrator != "0");
+
+if (_isHostageKill) then
+{
+	_perpetrator = objectFromNetID _perpetrator;
+
+	if (_killer == _perpetrator) then
+	{
+		_isHostageKill = false;
+	}
+	else
+	{
+		_killer = _perpetrator;
+	};
+};
 
 // Invalid Character ID
 if (_characterID == "0" or _playerID == "") exitWith { [_player] call BPServer_fnc_unitCleanup; };
@@ -85,7 +102,7 @@ if (!isNull _killer) then
 	[_playerID,_playerName,_killerID,_killerName,_killWeapon,_killDistance] call BPServer_fnc_killLog;
 	
 	// Headshot Check
-	if (_deathType == 16) then
+	if (_deathType == 16 && !_isHostageKill) then
 	{
 		//Fetch Current Headshot Count
 		_headshots = _killer getVariable ["headShots",0];
@@ -146,7 +163,7 @@ if (!isNull _killer) then
 
 	//Zombie Walking Player Killing
 	if ((_playerUniform in BP_ZombieClothing) || {_killerUniform in BP_ZombieClothing}) then {
-		if (_pointsChange < 0) then { _pointsChange = 0; };
+		if (!_isHostageKill && _pointsChange < 0) then { _pointsChange = 0; };
 	};
 	
 	//Mission Config Custom Points Division


### PR DESCRIPTION
Taking another player hostage will now have consequences for the perpetrator: If the hostage is harmed by another player (including gutting) leading to the victim's death the event will be treated as if the original kidnapper had killed/gutted the hostage. Taking allied classes hostage will therefore become a risky move that comes with responsibilities (by rendering the victim essentially defenseless) and might even force the kidnapper into defending his hostage from harm. On the other hand it is not possible to "steal" a kill from a player who has successfully managed to take a hostile class hostage.

Known issues:
-  It is possible for the kidnapper to avoid penalties by disconnecting before the hostage's death. The killer will still not be awarded any points making it at least still useless for farming points by abusing the faction system in this way. This could be countered to a certain degree by extending the the mechanism but at this time the risk of seeing wide-spread abuse of this flaw is considered too low to justify the effort.
- Since BP is treating a player being killed by zombies as suicide (and the killer-proxy currently not kicking in for suicides as that would include the disconnect-penalty) it is possible to take an allied class hostage and have them killed by zombies without invoking the penalty-system. Again: no benefit for points/stats padding so for now considered a low threat for abuse.