### PR TITLE
Fixed incorrect skeleton bone name cases.

### DIFF
--- a/ModSource/breakingpoint_classes/models/model.cfg
+++ b/ModSource/breakingpoint_classes/models/model.cfg
@@ -6,61 +6,25 @@ class CfgSkeletons
 		skeletonInherit = "";
 		skeletonBones[] = {};
 	};
-	class OFP2_ManSkeleton
+	class OFP2_ManSkeleton: Default
 	{
 		isDiscrete = 0;
 		skeletonInherit = "";
-		skeletonBones[] =
+		SkeletonBones[]=
 		{
 			"Pelvis","",
 			"Spine","Pelvis",
 			"Spine1","Spine",
 			"Spine2","Spine1",
 			"Spine3","Spine2",
-			"Camera","Pelvis",
+			"camera","Pelvis",// case has changed for arma3
 			"weapon","Spine1",
 			"launcher","Spine1",
-		//Head skeleton in hierarchy
-			"neck","Spine3",
-			"neck1","neck",
-			"head","neck1",
-		//New facial features
-			"Face_Hub","head",
-				"Face_Jawbone","Face_Hub",
-					"Face_Jowl","Face_Jawbone",
-					"Face_chopRight","Face_Jawbone",
-					"Face_chopLeft","Face_Jawbone",
-					"Face_LipLowerMiddle","Face_Jawbone",
-					"Face_LipLowerLeft","Face_Jawbone",
-					"Face_LipLowerRight","Face_Jawbone",
-					"Face_Chin","Face_Jawbone",
-					"Face_Tongue","Face_Jawbone",
-				"Face_CornerRight","Face_Hub",
-					"Face_CheekSideRight","Face_CornerRight",
-				"Face_CornerLeft","Face_Hub",
-					"Face_CheekSideLeft","Face_CornerLeft",
-				"Face_CheekFrontRight","Face_Hub",
-				"Face_CheekFrontLeft","Face_Hub",
-				"Face_CheekUpperRight","Face_Hub",
-				"Face_CheekUpperLeft","Face_Hub",
-				"Face_LipUpperMiddle","Face_Hub",
-				"Face_LipUpperRight","Face_Hub",
-				"Face_LipUpperLeft","Face_Hub",
-				"Face_NostrilRight","Face_Hub",
-				"Face_NostrilLeft","Face_Hub",
-				"Face_Forehead","Face_Hub",
-					"Face_BrowFrontRight","Face_Forehead",
-					"Face_BrowFrontLeft","Face_Forehead",
-					"Face_BrowMiddle","Face_Forehead",
-					"Face_BrowSideRight","Face_Forehead",
-					"Face_BrowSideLeft","Face_Forehead",
-				"Face_Eyelids","Face_Hub",
-				"Face_EyelidUpperRight","Face_Hub",
-				"Face_EyelidLowerRight","Face_Hub",
-				"Face_EyelidUpperLeft","Face_Hub",
-				"Face_EyelidLowerLeft","Face_Hub",
-				"EyeLeft","Face_Hub",
-				"EyeRight","Face_Hub",			
+			//Head skeleton in hierarchy
+			"Neck","Spine3",
+			"Neck1","Neck",
+			"Head","Neck1",
+
 		//Left upper side
 			"LeftShoulder","Spine3",
 			"LeftArm","LeftShoulder",
@@ -120,8 +84,46 @@ class CfgSkeletons
 			"RightLeg","RightUpLegRoll",
 			"RightLegRoll","RightLeg",
 			"RightFoot","RightLegRoll",
-			"RightToeBase","RightFoot"
-		};
+			"RightToeBase","RightFoot",
+
+			//New facial features arma3 only
+			"Face_Hub","Head",
+				"Face_Jawbone","Face_Hub",
+					"Face_Jowl","Face_Jawbone",
+					"Face_chopRight","Face_Jawbone",
+					"Face_chopLeft","Face_Jawbone",
+					"Face_LipLowerMiddle","Face_Jawbone",
+					"Face_LipLowerLeft","Face_Jawbone",
+					"Face_LipLowerRight","Face_Jawbone",
+					"Face_Chin","Face_Jawbone",
+					"Face_Tongue","Face_Jawbone",
+				"Face_CornerRight","Face_Hub",
+					"Face_CheekSideRight","Face_CornerRight",
+				"Face_CornerLeft","Face_Hub",
+					"Face_CheekSideLeft","Face_CornerLeft",
+				"Face_CheekFrontRight","Face_Hub",
+				"Face_CheekFrontLeft","Face_Hub",
+				"Face_CheekUpperRight","Face_Hub",
+				"Face_CheekUpperLeft","Face_Hub",
+				"Face_LipUpperMiddle","Face_Hub",
+				"Face_LipUpperRight","Face_Hub",
+				"Face_LipUpperLeft","Face_Hub",
+				"Face_NostrilRight","Face_Hub",
+				"Face_NostrilLeft","Face_Hub",
+				"Face_Forehead","Face_Hub",
+					"Face_BrowFrontRight","Face_Forehead",
+					"Face_BrowFrontLeft","Face_Forehead",
+					"Face_BrowMiddle","Face_Forehead",
+					"Face_BrowSideRight","Face_Forehead",
+					"Face_BrowSideLeft","Face_Forehead",
+				"Face_Eyelids","Face_Hub",
+				"Face_EyelidUpperRight","Face_Hub",
+				"Face_EyelidUpperLeft","Face_Hub",
+				"Face_EyelidLowerRight","Face_Hub",
+				"Face_EyelidLowerLeft","Face_Hub",
+				"EyeLeft","Face_Hub",
+				"EyeRight","Face_Hub"
+		};// end of skeleton array
 		// location of pivot points (local axes) for hierarchical animation
 		pivotsModel="A3\anims_f\data\skeleton\SkeletonPivots.p3d";
   	};
@@ -135,7 +137,7 @@ class CfgModels
 		sections[] = {};
 		skeletonName = "";
 	};
-	class ArmaMan : Default
+	class ArmaMan: Default
 	{
 		htMin = 60;          // Minimum half-cooling time (in seconds)
 		htMax = 1800;        // Maximum half-cooling time (in seconds)
@@ -185,7 +187,7 @@ class CfgModels
 	class BP_EPack : ArmaMan {};
 	class BP_EPack2 : ArmaMan {};
 	class BP_VPack : ArmaMan {};
-	
+
 	class BP_CacheStandard : Default {
 		sections[] = {"crate", "crate2", "net", "net2", "net3", "net4"};
 	};


### PR DESCRIPTION
Fixed incorrect skeleton bone name cases causing the following issues post 1.78:
https://cdn.discordapp.com/attachments/360843128292245517/385839137527300106/20171130170418_1.jpg

This change also fixes the same bone name issues resulting in vests, uniforms and backpacks on player models being incorrectly positioned at their feet.