### PR TITLE
Mitigate risk of drops clipping through the ground

### DIFF
--- a/ModSource/breakingpoint_server/functions/Wrecks/fn_spawnCrashCargo.sqf
+++ b/ModSource/breakingpoint_server/functions/Wrecks/fn_spawnCrashCargo.sqf
@@ -53,7 +53,7 @@ _startTime = time;
 _crashwreck = createVehicle [_heliModel,_heliStart, [], 0, "FLY"];
 _crashwreck setVariable ["permaLoot",true];
 _crashwreck engineOn true;
-_crashwreck flyInHeight 60;
+_crashwreck flyInHeight 80;
 _crashwreck forceSpeed 360;
 _crashwreck setSpeedMode "FULL";
 _crashwreck allowDamage false;
@@ -111,8 +111,8 @@ if (_preWaypoints > 0) then
 				["spawnCrashSite: Cutting Ropes %1",(ropes _crashwreck)] call BP_fnc_debugConsoleFormat;
 				{ ropeCut [_x, 5]; } count (ropes _crashwreck);
 
-				//Delay a Second
-				sleep 1;
+				//Delay deployment of parachute to allow the package to gain some distance from the chopper
+				sleep 2.5;
 
 				//Create Parachute
 				["spawnCrashSite: Deploying Parachute"] call BP_fnc_debugConsoleFormat;
@@ -121,7 +121,7 @@ if (_preWaypoints > 0) then
 				_para setDir getDir _cargo;
 				_para setPos getPos _cargo;
 				//_cargo attachTo [_para, [0,2,0]];
-				_cargo attachTo [_para, [0,1,0]];
+				_cargo attachTo [_para, [0,0,0.9]];
 
 				//Handle Parachute Cleanup when Crate Hits Ground
 				_handle = [_para,_cargo] spawn {
@@ -130,15 +130,15 @@ if (_preWaypoints > 0) then
 
 					//Wait Until Cargo Touching Ground
 					_fallTime = diag_tickTime;
-					waitUntil {isTouchingGround _cargo || ((diag_tickTime - _fallTime) > 15)};
+					waitUntil {((getPosATL _cargo) select 2 < 0.5 || (isTouchingGround _cargo) || ((diag_tickTime - _fallTime) > 30))};
 
 					//Deattach Crate and Delete Parachute
 					detach _cargo;
 					deleteVehicle _para;
 
 					//Start Smoke
-					_smokePos = getPosATL _cargo;
-					_smokeObj = createVehicle ["BP_SmokeShell", _smokePos, [], 0, "CAN_COLLIDE"];
+					_smokeObj = createVehicle ["BP_SmokeShell", [0, 0, 0], [], 0, "CAN_COLLIDE"];
+					_smokeObj attachTo [_cargo, [0,0.4,0]];
 					_smokeObj setVariable ["permaLoot",true];
 				};
 			};


### PR DESCRIPTION
- Tweaked condition for detaching parachute from care package (isTouchingGround is apparently not reliable for attached objects and the parachute kept pushing the package below ground - secondary checks are still in as a fallback)
- Adjusted the attachment point for the parachute (seemed to be off since last ArmA update)
- Delayed deployment of parachute a little further (and adjusted drop/flight height) allowing the drop to gain more distance from the helicopter so the parachute doesn't collide with the next care package
- Attached smoke shell to care package (in retrospect the previous behaviour made a lot of less experienced players make bogus bug reports assuming that the supply crate had glitched rather than realising that some other player had most likely airlifted the package away - also, in more complex terrain with lots of obstacles the smoke shell would sometimes deploy before the package had reached its final position - often even mid-air)