### PR TITLE
New Feature : only allied factions are able to group

### DIFF
--- a/ModSource/breakingpoint_client/functions/Init/fn_initVarsOnce.sqf
+++ b/ModSource/breakingpoint_client/functions/Init/fn_initVarsOnce.sqf
@@ -354,6 +354,16 @@ BP_Factions_Hunter = (getNumber (_cfgSettings >> "Factions" >> "Classes" >> "hun
 BP_Factions_Nomad = (getNumber (_cfgSettings >> "Factions" >> "Classes" >> "nomad") == 1);
 BP_Factions_Survivalist = (getNumber (_cfgSettings >> "Factions" >> "Classes" >> "survivalist") == 1);
 
+BP_Factions_disableMixedgrouping = false;
+
+if(isText (_cfgSettings >> "Factions" >> "disableMixedgrouping")) then
+{
+	if(getNumber (_cfgSettings >> "Factions" >> "disableMixedgrouping") == 1) then
+	{
+		BP_Factions_disableMixedgrouping = true;
+	};
+};
+
 BP_Factions_Points = (getNumber (_cfgSettings >> "Factions" >> "Points" >> "enabled") == 1);
 BP_Factions_PointsRatio = getNumber (_cfgSettings >> "Factions" >> "Points" >> "ratio");
 

--- a/ModSource/breakingpoint_client/functions/Player/fn_selfActions.sqf
+++ b/ModSource/breakingpoint_client/functions/Player/fn_selfActions.sqf
@@ -347,6 +347,39 @@ if (!isNull _cursorTarget and !_inVehicle and (player distance _cursorTarget < 6
 	_lowBlood = _cursorTarget getVariable ["med_lowBlood", false];
 	_isUndead = (player getVariable ["class",0] == 7);
 	_targetUndead = (_cursorTarget getVariable ["class",0] == 7);
+	_sameFaction = false;
+	if(BP_Factions_disableMixedgrouping) then
+	{
+		_playerClass = player getVariable ["class",0];
+		_cursorTargetClass =_cursorTarget getVariable ["class",0];
+		if (_playerClass in [0,3] && _cursorTargetClass in [0,3]) then
+		{
+			_sameFaction = true;
+		}
+		else
+		{
+			if (_playerClass in [1,4,5] && _cursorTargetClass in [1,4,5]) then
+			{
+				_sameFaction = true;
+			}
+			else
+			{
+				if (_playerClass == 2 && _cursorTargetClass == 2) then
+				{
+					_sameFaction = true;
+				}
+				else
+				{
+					_sameFaction = false;
+				};
+			};
+		};
+	}
+	else
+	{
+		_sameFaction = true;
+	};
+	
 
 	//Dog
 	_isDog = (_cursorTarget isKindOf "BP_Dog");
@@ -561,7 +594,7 @@ if (!isNull _cursorTarget and !_inVehicle and (player distance _cursorTarget < 6
 	};
 
 	/* Add To Group */
-	if (_isPlayer and !_isInMyGroup and !_isUndead and !_targetUndead and _isAlive and _isPlayerChar and _canDo) then {
+	if (_isPlayer and !_isInMyGroup and !_isUndead and !_targetUndead and _isAlive and _isPlayerChar and _canDo and _sameFaction) then {
 		if (s_player_groupAdd < 0) then {
 			s_player_groupAdd = player addAction ["Add To Group", { _this call BP_fnc_groupAdd; },_cursorTarget, 1, false, true, "", ""];
 		};

--- a/ModSource/breakingpoint_code/MPScenarios/BP10_BreakingPoint.Bornholm/description.ext
+++ b/ModSource/breakingpoint_code/MPScenarios/BP10_BreakingPoint.Bornholm/description.ext
@@ -87,6 +87,14 @@ class BreakingPoint
 			//Enable or Disable Faction System
 			enabled = true;
 			
+			/*
+			disable groups of different classes/faction , only players of the same faction will be able to group
+			[Ranger Nomads and Survivallists] , [Outlaw] , [Hunter, Independent/None] are able to group each other in the []
+			false => normal grouping is active
+			true => only players of the same class/faction are allowed to group 
+			*/
+			disableMixedgrouping = false;
+			
 			//Enable or Disable Point Gain and Loss
 			class Points
 			{

--- a/ModSource/breakingpoint_code/MPScenarios/BP1_BreakingPoint.Altis/description.ext
+++ b/ModSource/breakingpoint_code/MPScenarios/BP1_BreakingPoint.Altis/description.ext
@@ -127,6 +127,14 @@ class BreakingPoint
 			//Enable or Disable Faction System
 			enabled = true;
 			
+			/*
+			disable groups of different classes/faction , only players of the same faction will be able to group
+			[Ranger Nomads and Survivallists] , [Outlaw] , [Hunter, Independent/None] are able to group each other in the []
+			false => normal grouping is active
+			true => only players of the same class/faction are allowed to group 
+			*/
+			disableMixedgrouping = false;
+			
 			//Enable or Disable Point Gain and Loss
 			class Points
 			{

--- a/ModSource/breakingpoint_code/MPScenarios/BP1_BreakingPoint_Dev.Altis/description.ext
+++ b/ModSource/breakingpoint_code/MPScenarios/BP1_BreakingPoint_Dev.Altis/description.ext
@@ -107,6 +107,14 @@ class BreakingPoint
 			//Enable or Disable Faction System
 			enabled = true;
 			
+			/*
+			disable groups of different classes/faction , only players of the same faction will be able to group
+			[Ranger Nomads and Survivallists] , [Outlaw] , [Hunter, Independent/None] are able to group each other in the []
+			false => normal grouping is active
+			true => only players of the same class/faction are allowed to group 
+			*/
+			disableMixedgrouping = false;
+			
 			//Enable or Disable Point Gain and Loss
 			class Points
 			{

--- a/ModSource/breakingpoint_code/MPScenarios/BP2_BreakingPoint.Stratis/description.ext
+++ b/ModSource/breakingpoint_code/MPScenarios/BP2_BreakingPoint.Stratis/description.ext
@@ -104,6 +104,14 @@ class BreakingPoint
 			//Enable or Disable Faction System
 			enabled = true;
 			
+			/*
+			disable groups of different classes/faction , only players of the same faction will be able to group
+			[Ranger Nomads and Survivallists] , [Outlaw] , [Hunter, Independent/None] are able to group each other in the []
+			false => normal grouping is active
+			true => only players of the same class/faction are allowed to group 
+			*/
+			disableMixedgrouping = false;
+			
 			//Enable or Disable Point Gain and Loss
 			class Points
 			{

--- a/ModSource/breakingpoint_code/MPScenarios/BP3_BreakingPoint.ThirskW/description.ext
+++ b/ModSource/breakingpoint_code/MPScenarios/BP3_BreakingPoint.ThirskW/description.ext
@@ -108,6 +108,14 @@ class BreakingPoint
 			//Enable or Disable Faction System
 			enabled = true;
 			
+			/*
+			disable groups of different classes/faction , only players of the same faction will be able to group
+			[Ranger Nomads and Survivallists] , [Outlaw] , [Hunter, Independent/None] are able to group each other in the []
+			false => normal grouping is active
+			true => only players of the same class/faction are allowed to group 
+			*/
+			disableMixedgrouping = false;
+			
 			//Enable or Disable Point Gain and Loss
 			class Points
 			{

--- a/ModSource/breakingpoint_code/MPScenarios/BP4_BreakingPoint.Thirsk/description.ext
+++ b/ModSource/breakingpoint_code/MPScenarios/BP4_BreakingPoint.Thirsk/description.ext
@@ -108,6 +108,14 @@ class BreakingPoint
 			//Enable or Disable Faction System
 			enabled = true;
 			
+			/*
+			disable groups of different classes/faction , only players of the same faction will be able to group
+			[Ranger Nomads and Survivallists] , [Outlaw] , [Hunter, Independent/None] are able to group each other in the []
+			false => normal grouping is active
+			true => only players of the same class/faction are allowed to group 
+			*/
+			disableMixedgrouping = false;
+			
 			//Enable or Disable Point Gain and Loss
 			class Points
 			{

--- a/ModSource/breakingpoint_code/MPScenarios/BP5_BreakingPoint.Tanoa/description.ext
+++ b/ModSource/breakingpoint_code/MPScenarios/BP5_BreakingPoint.Tanoa/description.ext
@@ -228,6 +228,14 @@ class BreakingPoint
 			//Enable or Disable Faction System
 			enabled = true;
 			
+			/*
+			disable groups of different classes/faction , only players of the same faction will be able to group
+			[Ranger Nomads and Survivallists] , [Outlaw] , [Hunter, Independent/None] are able to group each other in the []
+			false => normal grouping is active
+			true => only players of the same class/faction are allowed to group 
+			*/
+			disableMixedgrouping = false;
+			
 			//Enable or Disable Point Gain and Loss
 			class Points
 			{

--- a/ModSource/breakingpoint_code/MPScenarios/BP5_BreakingPoint_Dev.Tanoa/description.ext
+++ b/ModSource/breakingpoint_code/MPScenarios/BP5_BreakingPoint_Dev.Tanoa/description.ext
@@ -128,6 +128,14 @@ class BreakingPoint
 			//Enable or Disable Faction System
 			enabled = true;
 			
+			/*
+			disable groups of different classes/faction , only players of the same faction will be able to group
+			[Ranger Nomads and Survivallists] , [Outlaw] , [Hunter, Independent/None] are able to group each other in the []
+			false => normal grouping is active
+			true => only players of the same class/faction are allowed to group 
+			*/
+			disableMixedgrouping = false;
+			
 			//Enable or Disable Point Gain and Loss
 			class Points
 			{

--- a/ModSource/breakingpoint_code/MPScenarios/BP6_BreakingPoint.newhaven/description.ext
+++ b/ModSource/breakingpoint_code/MPScenarios/BP6_BreakingPoint.newhaven/description.ext
@@ -118,6 +118,14 @@ class BreakingPoint
 			//Enable or Disable Faction System
 			enabled = true;
 			
+			/*
+			disable groups of different classes/faction , only players of the same faction will be able to group
+			[Ranger Nomads and Survivallists] , [Outlaw] , [Hunter, Independent/None] are able to group each other in the []
+			false => normal grouping is active
+			true => only players of the same class/faction are allowed to group 
+			*/
+			disableMixedgrouping = false;
+			
 			//Enable or Disable Point Gain and Loss
 			class Points
 			{

--- a/ModSource/breakingpoint_code/MPScenarios/BP7_BreakingPoint.Esseker/description.ext
+++ b/ModSource/breakingpoint_code/MPScenarios/BP7_BreakingPoint.Esseker/description.ext
@@ -126,6 +126,14 @@ class BreakingPoint
 			//Enable or Disable Faction System
 			enabled = true;
 			
+			/*
+			disable groups of different classes/faction , only players of the same faction will be able to group
+			[Ranger Nomads and Survivallists] , [Outlaw] , [Hunter, Independent/None] are able to group each other in the []
+			false => normal grouping is active
+			true => only players of the same class/faction are allowed to group 
+			*/
+			disableMixedgrouping = false;
+			
 			//Enable or Disable Point Gain and Loss
 			class Points
 			{

--- a/ModSource/breakingpoint_code/MPScenarios/BP7_BreakingPoint_Dev.Esseker/description.ext
+++ b/ModSource/breakingpoint_code/MPScenarios/BP7_BreakingPoint_Dev.Esseker/description.ext
@@ -120,6 +120,14 @@ class BreakingPoint
 			//Enable or Disable Faction System
 			enabled = true;
 			
+			/*
+			disable groups of different classes/faction , only players of the same faction will be able to group
+			[Ranger Nomads and Survivallists] , [Outlaw] , [Hunter, Independent/None] are able to group each other in the []
+			false => normal grouping is active
+			true => only players of the same class/faction are allowed to group 
+			*/
+			disableMixedgrouping = false;
+			
 			//Enable or Disable Point Gain and Loss
 			class Points
 			{

--- a/ModSource/breakingpoint_code/MPScenarios/BP8_BreakingPoint.Chernarus/description.ext
+++ b/ModSource/breakingpoint_code/MPScenarios/BP8_BreakingPoint.Chernarus/description.ext
@@ -144,6 +144,14 @@ class BreakingPoint
 			//Enable or Disable Faction System
 			enabled = true;
 			
+			/*
+			disable groups of different classes/faction , only players of the same faction will be able to group
+			[Ranger Nomads and Survivallists] , [Outlaw] , [Hunter, Independent/None] are able to group each other in the []
+			false => normal grouping is active
+			true => only players of the same class/faction are allowed to group 
+			*/
+			disableMixedgrouping = false;
+			
 			//Enable or Disable Point Gain and Loss
 			class Points
 			{

--- a/ModSource/breakingpoint_code/MPScenarios/BP8_BreakingPoint_Dev.Chernarus/description.ext
+++ b/ModSource/breakingpoint_code/MPScenarios/BP8_BreakingPoint_Dev.Chernarus/description.ext
@@ -144,6 +144,14 @@ class BreakingPoint
 			//Enable or Disable Faction System
 			enabled = true;
 			
+			/*
+			disable groups of different classes/faction , only players of the same faction will be able to group
+			[Ranger Nomads and Survivallists] , [Outlaw] , [Hunter, Independent/None] are able to group each other in the []
+			false => normal grouping is active
+			true => only players of the same class/faction are allowed to group 
+			*/
+			disableMixedgrouping = false;
+			
 			//Enable or Disable Point Gain and Loss
 			class Points
 			{

--- a/ModSource/breakingpoint_code/MPScenarios/BP9_BreakingPoint.namalsk/description.ext
+++ b/ModSource/breakingpoint_code/MPScenarios/BP9_BreakingPoint.namalsk/description.ext
@@ -151,6 +151,14 @@ class BreakingPoint
 			//Enable or Disable Faction System
 			enabled = true;
 			
+			/*
+			disable groups of different classes/faction , only players of the same faction will be able to group
+			[Ranger Nomads and Survivallists] , [Outlaw] , [Hunter, Independent/None] are able to group each other in the []
+			false => normal grouping is active
+			true => only players of the same class/faction are allowed to group 
+			*/
+			disableMixedgrouping = false;
+			
 			//Enable or Disable Point Gain and Loss
 			class Points
 			{

--- a/ModSource/breakingpoint_code/MPScenarios/BP9_BreakingPoint_Dev.namalsk/description.ext
+++ b/ModSource/breakingpoint_code/MPScenarios/BP9_BreakingPoint_Dev.namalsk/description.ext
@@ -116,6 +116,14 @@ class BreakingPoint
 			//Enable or Disable Faction System
 			enabled = true;
 			
+			/*
+			disable groups of different classes/faction , only players of the same faction will be able to group
+			[Ranger Nomads and Survivallists] , [Outlaw] , [Hunter, Independent/None] are able to group each other in the []
+			false => normal grouping is active
+			true => only players of the same class/faction are allowed to group 
+			*/
+			disableMixedgrouping = false;
+			
 			//Enable or Disable Point Gain and Loss
 			class Points
 			{

--- a/ModSource/breakingpoint_server/functions/Login/fn_playerLogin.sqf
+++ b/ModSource/breakingpoint_server/functions/Login/fn_playerLogin.sqf
@@ -148,20 +148,82 @@ _validLegion = false;
 
 if(!_groupTimerActive) then
 {
-	//Persistent Groups
-	if (_clan != "0") then
+	if(BP_Factions_disableMixedgrouping) then
 	{
-		_squadData = squadParams _player;
-		if !(_squadData isEqualTo []) then
+		_legionDataVarName="";
+		_groupID="";
+		if (_clan != "0") then //DB Groups
 		{
-			_squadData params ["_squadDetails","_memberDetails"];
-			_squadDetails params ["_squadNick","_squadName","_squadEmail"];
-			if (_squadEmail == _clan) then
+			_squadData = squadParams _player;
+			if !(_squadData isEqualTo []) then
 			{
-				_validLegion = true;
-				_body setVariable ["group",_clan,true];
-				_body setVariable ["groupTag",_squadNick,false];
-				_body setVariable ["groupName",_squadName,false];
+				_squadData params ["_squadDetails","_memberDetails"];
+				_squadDetails params ["_squadNick","_squadName","_squadEmail"];
+				if (!(_squadNick isEqualTo []) && !(_squadName isEqualTo "")) then
+				{
+					if(_class == -1) then
+					{
+						_body setVariable ["clan", _clan];//when there is no class to process (respawn) it will be handeled in the fn_playerSetup.sqf
+						_validLegion = true;
+					}
+					else
+					{
+						if (_class in [0,3]) then
+						{													//Legion Data Database
+							_legionDataVarName = format["BP_LDDB_Bandit:%1", _clanDB];//None-Hunter
+						}
+						else
+						{
+							if (_class in [1,4,5]) then
+							{
+								_legionDataVarName = format["BP_LDDB_Friendly:%1", _clanDB];//Nomad-Ranger-Survialist
+							}
+							else
+							{
+								if(_class == 2) then
+								{
+									_legionDataVarName = format["BP_LDDB_Outlaw:%1", _clanDB];//Outlaw
+								};
+							};
+						};
+						if !(_legionDataVarName isEqualTo "") then
+						{
+							if !((missionNamespace getVariable [_legionDataVarName, ""]) isEqualTo "") then
+							{
+								_groupID = missionNamespace getVariable [_legionDataVarName, ""];
+							}
+							else
+							{
+								_groupID = call BP_fnc_groupCreateUID;
+								missionNamespace setVariable [_legionDataVarName, _groupID];
+							};
+							_body setVariable ["group", _groupID, true];
+							_body setVariable ["groupTag", _squadNick];
+							_body setVariable ["groupName", _squadName];
+							_validLegion = true;
+						};
+					};
+				};
+			};
+		};
+	}
+	else
+	{
+		//Persistent Groups
+		if (_clan != "0") then
+		{
+			_squadData = squadParams _player;
+			if !(_squadData isEqualTo []) then
+			{
+				_squadData params ["_squadDetails","_memberDetails"];
+				_squadDetails params ["_squadNick","_squadName","_squadEmail"];
+				if (_squadEmail == _clan) then
+				{
+					_validLegion = true;
+					_body setVariable ["group",_clan,true];
+					_body setVariable ["groupTag",_squadNick,false];
+					_body setVariable ["groupName",_squadName,false];
+				};
 			};
 		};
 	};

--- a/ModSource/breakingpoint_server/functions/Login/fn_playerLogin.sqf
+++ b/ModSource/breakingpoint_server/functions/Login/fn_playerLogin.sqf
@@ -170,19 +170,19 @@ if(!_groupTimerActive) then
 					{
 						if (_class in [0,3]) then
 						{													//Legion Data Database
-							_legionDataVarName = format["BP_LDDB_Bandit:%1", _clanDB];//None-Hunter
+							_legionDataVarName = format["BP_LDDB_Bandit:%1", _clan];//None-Hunter
 						}
 						else
 						{
 							if (_class in [1,4,5]) then
 							{
-								_legionDataVarName = format["BP_LDDB_Friendly:%1", _clanDB];//Nomad-Ranger-Survialist
+								_legionDataVarName = format["BP_LDDB_Friendly:%1", _clan];//Nomad-Ranger-Survialist
 							}
 							else
 							{
 								if(_class == 2) then
 								{
-									_legionDataVarName = format["BP_LDDB_Outlaw:%1", _clanDB];//Outlaw
+									_legionDataVarName = format["BP_LDDB_Outlaw:%1", _clan];//Outlaw
 								};
 							};
 						};

--- a/ModSource/breakingpoint_server/functions/Login/fn_playerSetup.sqf
+++ b/ModSource/breakingpoint_server/functions/Login/fn_playerSetup.sqf
@@ -44,6 +44,54 @@ if (count _this > 2) then
 	//Spawn Class Gear
 	[_player,_class] call BPServer_fnc_factionGear;
 
+	//Handle Groups
+	if(BP_Factions_disableMixedgrouping) then
+	{
+		_legionDataVarName="";
+		_groupID="";
+		_clanDB = _player getVariable ["clan","0"];
+		if (_clanDB != "0") then //DB Groups
+		{
+			_squadData = squadParams _logic;
+			_squadData params ["_squadDetails","_memberDetails"];
+			_squadDetails params ["_squadNick","_squadName","_squadEmail"];
+			if (_class in [0,3]) then
+			{													//Legion Data Database
+				_legionDataVarName = format["BP_LDDB_Bandit:%1", _clanDB];//None-Hunter
+			}
+			else
+			{
+				if (_class in [1,4,5]) then
+				{
+					_legionDataVarName = format["BP_LDDB_Friendly:%1", _clanDB];//Nomad-Ranger-Survialist
+				}
+				else
+				{
+					if(_class == 2) then
+					{
+						_legionDataVarName = format["BP_LDDB_Outlaw:%1", _clanDB];//Outlaw
+					};
+				};
+			};
+			if !(_legionDataVarName isEqualTo "") then
+			{
+				if !((missionNamespace getVariable [_legionDataVarName, ""]) isEqualTo "") then
+				{
+					_groupID = missionNamespace getVariable [_legionDataVarName, ""];
+				}
+				else
+				{
+					_groupID = call BP_fnc_groupCreateUID;
+					missionNamespace setVariable [_legionDataVarName, _groupID];
+				};
+				_player setVariable ["group", _groupID, true];
+				_player setVariable ["groupTag", _squadNick];
+				_player setVariable ["groupName", _squadName];
+				_validLegion = true;
+			};
+		};
+	};
+	
 	//Handle Spawn Selection
 	call
 	{

--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Breaking Point Mod is a total conversion mod for Arma 3. Source is provided for 
 * New Feature : only allied factions are able to group.
 To enable this feature use one of the build in missions in the client files and edit the
 description.ext
+
 Look for 
 ```
 class Factions
@@ -137,7 +138,7 @@ class Factions
 	...
 };	
 ```
-If disableMixedgrouping does not exist in the description file it will be automaticaly disabled => false
+If disableMixedgrouping does not exist in the description file it will be automaticaly disabled => false.
 By default this feature is disabled.
 
 

--- a/README.md
+++ b/README.md
@@ -123,6 +123,23 @@ Breaking Point Mod is a total conversion mod for Arma 3. Source is provided for 
 * Edit the config.cpp in the "breakingpoint_server_config" to your server liking
 * Pack the folder "breakingpoint_server_config" to a .pbo and put it in your server root directory inside "@BreakingPointServer/addons"
 
+### Missionconfig
+* in each Mission provided with the mod there is a missionconfig file called "description.ext" change it to your liking
+* New Feature : only allied factions are able to group
+To enable this feature use one of the build in missions in the client files and edit the
+description.ext
+Look for 
+```
+class Factions
+{
+	...
+	disableMixedgrouping = true; // true = enabled => only allied factions are allowed to group
+	...
+};	
+```
+If disableMixedgrouping does not exist in the description file it will be automaticaly disabled => false
+By default this feature is disabled.
+
 
 ## Credits/Notable mentions.
 * DeathlyRage - For tirelessly working hard over the years to maintain and develop such a high quality mod.

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Breaking Point Mod is a total conversion mod for Arma 3. Source is provided for 
 
 ### Missionconfig
 * in each Mission provided with the mod there is a missionconfig file called "description.ext" change it to your liking
-* New Feature : only allied factions are able to group
+* New Feature : only allied factions are able to group.
 To enable this feature use one of the build in missions in the client files and edit the
 description.ext
 Look for 


### PR DESCRIPTION
## Description

This feature allows server owners to decide if they want to disable grouping/mixedgrouping of all factions.

When this is enabled it will only allow grouping of allied factions.
That means for example a Ranger can't group with a Hunter or Independent or Outlaw but with other Ranger, Nomads and Survivalists.

**Allied factions are:**
[Ranger, Nomad, Survivalist]
[Hunter, None/Independent]
[Outlaw]

## Functionality
It will not show the "Add to group" action in the scroll menue when your target is not allied to your faction.

This feature also supports legions,

When in a Legion it will automatical group each allied Faction in that legion to its own group.

That means if a Legion with 
2 x Ranger 
2 x Nomad 
2 x Survivalist 
2 x Outlaw
2 x Hunter
2 x None/Independent 

will be split into a (Ranger, Nomad, Survivalist) group, a (Hunter, None/Independent) group and a Outlaw group.

The Ranger, Nomads and the Survivalist will be in one group.
The Outlaws will be in thier own group.
The Hunter and the None/Intependet will be intheir own group.

**Attention** this will only work with Database Legions like it is in Github if you want it to work also with XML/Squads/Units or what ever you call them just ask me for the modification.

## Configuration:
To enable this feature use one of the build in mission in the client files and edit the
description.ext
look for **class Factions** and set **disableMixedgrouping = true** and that is it.

If disableMixedgrouping does not exist in the description file it will be automaticaly disabled => false
By default this feature is disabled.

Special thanks to @KamikazeXeX 
this Feature is build up on his XML Legion system.