### PR TITLE
Update fn_getFactionKillPoints.sqf

### DIFF
--- a/ModSource/breakingpoint_functions/functions/Faction/fn_getFactionKillPoints.sqf
+++ b/ModSource/breakingpoint_functions/functions/Faction/fn_getFactionKillPoints.sqf
@@ -19,7 +19,7 @@ params [["_victim",objNull,[objNull]],["_killer",objNull,[objNull]]];
 if (isNull _victim) exitWith {0};
 if (isNull _killer) exitWith {0};
 
-if (_killer isEqualTo _victim) exitWith {["getFactionKillPoints: Victim == Killer: no points change"] BP_fnc_debugConsoleFormat};
+if (_killer isEqualTo _victim) exitWith {["getFactionKillPoints: Victim == Killer: no points change"] call BP_fnc_debugConsoleFormat};
 
 _nearbyStronghold = [_victim] call BP_fnc_strongholdNearby;
 


### PR DESCRIPTION
I assume it's missing a call where I added it as it's throwing an error

11:56:16 Error in expression <s: Victim == Killer: no points change"] BP_fnc_debugConsoleFormat};

_nearbyStro>
11:56:16   Error position: <BP_fnc_debugConsoleFormat};

_nearbyStro>
11:56:16   Error Missing ;
11:56:16 File breakingpoint_functions\functions\Faction\fn_getFactionKillPoints.sqf, line 22