### PR TITLE
Updated medical assistance

### DIFF
--- a/ModSource/breakingpoint_functions/functions/Faction/fn_getFactionKillPoints.sqf
+++ b/ModSource/breakingpoint_functions/functions/Faction/fn_getFactionKillPoints.sqf
@@ -19,8 +19,6 @@ params [["_victim",objNull,[objNull]],["_killer",objNull,[objNull]]];
 if (isNull _victim) exitWith {0};
 if (isNull _killer) exitWith {0};
 
-if (_killer isEqualTo _victim) exitWith {["getFactionKillPoints: Victim == Killer: no points change"] call BP_fnc_debugConsoleFormat;};
-
 _nearbyStronghold = [_victim] call BP_fnc_strongholdNearby;
 
 //Victim
@@ -37,6 +35,12 @@ _killerFactionPoints = _killer call BP_fnc_getFactionPoints;
 
 _levelStr = format ["Level_%1",_victimFactionLevel];
 _pointsChange = getNumber (configFile >> "CfgFactions" >> _killerFactionName >> "Points" >> "Kill" >> _victimFactionName >> _levelStr);
+
+if (_killer isEqualTo _victim) then
+{
+	["getFactionKillPoints: Victim == Killer: no points change"] call BP_fnc_debugConsoleFormat;
+	_pointsChange = 0;
+};
 
 ["getFactionKillPoints: Victim: %1 (%2 %3) | Killer: %4 (%5 %6) | Points: %7 | LevelStr: %8",_victim,_victimFactionName,_victimFactionPoints,_killer,_killerFactionName,_killerFactionPoints,_pointsChange,_levelStr] call BP_fnc_debugConsoleFormat;
 

--- a/ModSource/breakingpoint_functions/functions/Faction/fn_getFactionKillPoints.sqf
+++ b/ModSource/breakingpoint_functions/functions/Faction/fn_getFactionKillPoints.sqf
@@ -19,7 +19,7 @@ params [["_victim",objNull,[objNull]],["_killer",objNull,[objNull]]];
 if (isNull _victim) exitWith {0};
 if (isNull _killer) exitWith {0};
 
-if (_killer isEqualTo _victim) exitWith {["getFactionKillPoints: Victim == Killer: no points change"] BP_fnc_debugConsoleFormat};
+if (_killer isEqualTo _victim) exitWith {["getFactionKillPoints: Victim == Killer: no points change"] call BP_fnc_debugConsoleFormat;};
 
 _nearbyStronghold = [_victim] call BP_fnc_strongholdNearby;
 

--- a/ModSource/breakingpoint_server/CfgFunctions.hpp
+++ b/ModSource/breakingpoint_server/CfgFunctions.hpp
@@ -233,6 +233,7 @@ class CfgFunctions
 			class containerSpawn {};
 			class simulationToggle {};
 			class igniteEntity {};
+			class checkHealRecent {};
 		};
 		class Wrecks {
 			file = "\breakingpoint_server\functions\Wrecks";

--- a/ModSource/breakingpoint_server/config.cpp
+++ b/ModSource/breakingpoint_server/config.cpp
@@ -44,15 +44,19 @@ class CfgBreakingPointServerSettings
 	};
 	class CustomLoot
 	{
-		customLootSetting = 1;	// 0 = SC off 	1 = SC on 	2 = ghosthotel weapon insted of SC
+		customLootSetting = 1;	// 0 = SC off 		1 = SC on (default)	 	2 = ghosthotel weapon insted of SC
 	};
 	class MixedGroupPointsGain
 	{
-		disableMixedGroupPointsGain = 1;	//tunrs point gain for mixed group off, point lose still on 0 = off , 1 = on
+		disableMixedGroupPointsGain = 1;	//turns point gain for mixed group off, point lose still on 0 = off , 1 = on
 	};
 	class groupLeaveTimer
 	{
 		groupLeaveTimeOut = 600;	//time in seconds between leaving group and joining new/old one if  0 => Off
+	};
+	class applyMedicine
+	{
+		medicalCooldown = 900;	//time in seconds for point gain on medical assistance
 	};
 };
 

--- a/ModSource/breakingpoint_server/functions/Events/fn_checkHealRecent.sqf
+++ b/ModSource/breakingpoint_server/functions/Events/fn_checkHealRecent.sqf
@@ -1,0 +1,102 @@
+/*
+	Breaking Point Mod for Arma 3
+
+	Released under Arma Public Share Like Licence (APL-SA)
+	https://www.bistudio.com/community/licenses/arma-public-license-share-alike
+
+	Alderon Games Pty Ltd
+
+	Written by Th3Dilli for the Breaking Point Mod for ArmA 3.
+*/
+
+params ["_event","_unitUID","_medicUID"];
+
+_healedRecently = false;
+
+_medicalCooldown = getNumber (configFile >> "CfgBreakingPointServerSettings" >> "applyMedicine" >> "medicalCooldown");
+
+
+switch (_event) do {
+	case "medBandage";
+	case "medFieldDressing":
+	{
+		{
+			if(_x select 0 == _unitUID && _x select 1 == _medicUID) then
+			{
+				if(_x select 2 > time) then
+				{
+					_healedRecently = true;
+				}
+				else
+				{
+					_x set [2,(time + _medicalCooldown)];
+				};
+			};
+		} foreach BP_applyBandage;
+		if(!_healedRecently) then
+		{
+			BP_applyBandage pushBack [_unitUID,_medicUID,(time + _medicalCooldown)];
+		};
+	};
+	case "medPainK":
+	{
+		{
+			if(_x select 0 == _unitUID && _x select 1 == _medicUID) then
+			{
+				if(_x select 2 > time) then
+				{
+					_healedRecently = true;
+				}
+				else
+				{
+					_x set [2,(time + _medicalCooldown)];
+				};
+			};
+		} foreach BP_applyPainkiller;
+		if(!_healedRecently) then
+		{
+			BP_applyPainkiller pushBack [_unitUID,_medicUID,(time + _medicalCooldown)];
+		};
+	};
+	case "medSurgery":
+	{
+		{
+			if(_x select 0 == _unitUID && _x select 1 == _medicUID) then
+			{
+				if(_x select 2 > time) then
+				{
+					_healedRecently = true;
+				}
+				else
+				{
+					_x set [2,(time + _medicalCooldown)];
+				};
+			};
+		} foreach BP_applySurgery;
+		if(!_healedRecently) then
+		{
+			BP_applySurgery pushBack [_unitUID,_medicUID,(time + _medicalCooldown)];
+		};
+	};
+	case "medMorphine":
+	{
+		{
+			if(_x select 0 == _unitUID && _x select 1 == _medicUID) then
+			{
+				if(_x select 2 > time) then
+				{
+					_healedRecently = true;
+				}
+				else
+				{
+					_x set [2,(time + _medicalCooldown)];
+				};
+			};
+		} foreach BP_applyMorphine;
+		if(!_healedRecently) then
+		{
+			BP_applyMorphine pushBack [_unitUID,_medicUID,(time + _medicalCooldown)];
+		};
+	};
+};
+_healedRecently

--- a/ModSource/breakingpoint_server/functions/Login/fn_playerLogin.sqf
+++ b/ModSource/breakingpoint_server/functions/Login/fn_playerLogin.sqf
@@ -301,14 +301,7 @@ _body setVariable ["messing",(_medical select 10)];
 
 //Misc ( No Need to Init Because Default Fetch Values )
 //_body setVariable ["recentKills",[]];
-//_body setVariable ["medBandage",[]];
-//_body setVariable ["medSurgery",[]];
-//_body setVariable ["medMorphine",[]];
-//_body setVariable ["medPainK",[]];
-//_body setVariable ["medBandageReset",diag_tickTime];
-//_body setVariable ["medSurgeryReset",diag_tickTime];
-//_body setVariable ["medMorphineReset",diag_tickTime];
-//_body setVariable ["medPainKReset",diag_tickTime];
+
 
 if (_isNew) then {
 	_body setVariable ["freshSpawn",true];

--- a/ModSource/breakingpoint_server/functions/Login/fn_playerLoginAI.sqf
+++ b/ModSource/breakingpoint_server/functions/Login/fn_playerLoginAI.sqf
@@ -49,15 +49,7 @@ _body setVariable ["dogID",0];
 _body setVariable ["recentKills",[]];
 _body setVariable ["med_BloodQty",(_medical select 8)];
 _body setVariable ["messing",(_medical select 10)];
-_body setVariable ["medBandage",[]];
-_body setVariable ["medSurgery",[]];
-_body setVariable ["medMorphine",[]];
-_body setVariable ["medPainK",[]];
-_body setVariable ["medBandageReset",diag_tickTime];
-_body setVariable ["medSurgeryReset",diag_tickTime];
-_body setVariable ["medMorphineReset",diag_tickTime];
-_body setVariable ["medPainKReset",diag_tickTime];
-_body setVariable ["medBandageReset",diag_tickTime];
+
 
 //Remove Player from disconnection list, because we terminated the script early due to hot reloading
 _index = BP_AntiDisconnectIDs find _playerID;

--- a/ModSource/breakingpoint_server/preInit.sqf
+++ b/ModSource/breakingpoint_server/preInit.sqf
@@ -91,6 +91,10 @@ BP_AntiDisconnectIDs = [];
 BP_AntiDisconnectObjs = [];
 BP_HackMagIDs = [];
 BP_groupLeaveTimers = [];
+BP_applyBandage = [];
+BP_applyPainkiller = [];
+BP_applySurgery = [];
+BP_applyMorphine = [];
 
 //Preload Code
 call compile preprocessFileLineNumbers "\breakingpoint_server\publicEH.sqf";

--- a/ServerConfiguration/breakingpoint_server_config/config.cpp
+++ b/ServerConfiguration/breakingpoint_server_config/config.cpp
@@ -18,15 +18,19 @@ class CfgBreakingPointServerSettings
 	};
 	class CustomLoot
 	{
-		customLootSetting = 1;	// 0 = SC off, 	1 = SC on (default),	2 = ghosthotel weapon insted of SC
+		customLootSetting = 1;	// 0 = SC off 		1 = SC on (default)	 	2 = ghosthotel weapon insted of SC
 	};
 	class MixedGroupPointsGain
 	{
-		disableMixedGroupPointsGain = 1;	//tunrs point gain for mixed group off, point lose still on 0 = off , 1 = on
+		disableMixedGroupPointsGain = 1;	//turns point gain for mixed group off, point lose still on 0 = off , 1 = on
 	};
 	class groupLeaveTimer
 	{
 		groupLeaveTimeOut = 600;	//time in seconds between leaving group and joining new/old one if  0 => Off
+	};
+	class applyMedicine
+	{
+		medicalCooldown = 900;	//time in seconds for point gain on medical assistance
 	};
 };
 
@@ -37,9 +41,9 @@ class CfgDifficultyPresets
 		class Options
 		{
 			waypoints=0;		// Waypoints Regular(3PP) (0 = never, 1 = fade out, 2 = always)
-		};
+		};		
 	};
-
+	
 	class Veteran
 	{
 		class Options


### PR DESCRIPTION
The problem was that the old system to detect if a player got healed by another player was bound to the player and after a soft relog you could do it again. That is now fixed with serverside variables and a configurable timer in the config file.