### PR TITLE
Hardcore zombies

### DIFF
--- a/ModSource/breakingpoint_code/Configs/CfgVehicles.hpp
+++ b/ModSource/breakingpoint_code/Configs/CfgVehicles.hpp
@@ -852,7 +852,7 @@ class CfgVehicles
 			mat[] = {};
 		};
 	};
-		
+	
 	
 	class CAManBase;
 	class BP_Man : CAManBase

--- a/ModSource/breakingpoint_code/Configs/CfgVehicles.hpp
+++ b/ModSource/breakingpoint_code/Configs/CfgVehicles.hpp
@@ -852,18 +852,9 @@ class CfgVehicles
 			mat[] = {};
 		};
 	};
+		
 	
-	class CAManBase: Man
-	{
-		class HitPoints
-		{
-			class HitHead;
-			class HitBody;
-			class HitHands;
-			class HitLegs;
-		};
-	};
-	
+	class CAManBase;
 	class BP_Man : CAManBase
 	{
 		class HitPoints 

--- a/ModSource/breakingpoint_code/Configs/CfgVehicles.hpp
+++ b/ModSource/breakingpoint_code/Configs/CfgVehicles.hpp
@@ -853,8 +853,17 @@ class CfgVehicles
 		};
 	};
 	
+	class CAManBase: Man
+	{
+		class HitPoints
+		{
+			class HitHead;
+			class HitBody;
+			class HitHands;
+			class HitLegs;
+		};
+	};
 	
-	class CAManBase;
 	class BP_Man : CAManBase
 	{
 		class HitPoints 

--- a/ModSource/breakingpoint_functions/functions/Medical/fn_damageHandlerZ.sqf
+++ b/ModSource/breakingpoint_functions/functions/Medical/fn_damageHandlerZ.sqf
@@ -9,6 +9,13 @@
 
 params ["_zed","_selection","_damage","_source","_projectile"];
 
+//Handle Damage being Applied
+//_hitpoint = "HitBody";
+if (_selection == "head_hit") then { 
+//_hitpoint = "HitHead"; 
+_zed setDamage 1;
+};
+
 ["damageHandlerZ: Zed: %1 | Selection: %2 | Damage: %3 | Source: %4 | Projectile: %5",_zed,_selection,_damage,_source,_projectile] call BP_fnc_debugConsoleFormat;
 
 /*

--- a/ModSource/breakingpoint_functions/functions/Medical/fn_damageHandlerZ.sqf
+++ b/ModSource/breakingpoint_functions/functions/Medical/fn_damageHandlerZ.sqf
@@ -9,13 +9,6 @@
 
 params ["_zed","_selection","_damage","_source","_projectile"];
 
-//Handle Damage being Applied
-//_hitpoint = "HitBody";
-if (_selection == "head_hit") then { 
-//_hitpoint = "HitHead"; 
-_zed setDamage 1;
-};
-
 ["damageHandlerZ: Zed: %1 | Selection: %2 | Damage: %3 | Source: %4 | Projectile: %5",_zed,_selection,_damage,_source,_projectile] call BP_fnc_debugConsoleFormat;
 
 /*

--- a/ModSource/breakingpoint_functions/functions/Medical/fn_damageHandlerZ.sqf
+++ b/ModSource/breakingpoint_functions/functions/Medical/fn_damageHandlerZ.sqf
@@ -104,4 +104,4 @@ if (isBurning _zed) then
 //_currentDmg = _currentDmg + _damage;
 //_unit setHitPointDamage [_hitpoint,_currentDmg];
 
-_damage
+//_damage

--- a/ModSource/breakingpoint_functions/functions/Medical/fn_damageHandlerZ.sqf
+++ b/ModSource/breakingpoint_functions/functions/Medical/fn_damageHandlerZ.sqf
@@ -13,7 +13,7 @@ params ["_zed","_selection","_damage","_source","_projectile"];
 //_hitpoint = "HitBody";
 if (_selection == "head_hit") then { 
 //_hitpoint = "HitHead"; 
-_zed setDamage 1;
+_zed setDamage (0.7 + random 0.6);
 };
 
 ["damageHandlerZ: Zed: %1 | Selection: %2 | Damage: %3 | Source: %4 | Projectile: %5",_zed,_selection,_damage,_source,_projectile] call BP_fnc_debugConsoleFormat;

--- a/ModSource/breakingpoint_functions/functions/Medical/fn_damageHandlerZ.sqf
+++ b/ModSource/breakingpoint_functions/functions/Medical/fn_damageHandlerZ.sqf
@@ -104,4 +104,4 @@ if (isBurning _zed) then
 //_currentDmg = _currentDmg + _damage;
 //_unit setHitPointDamage [_hitpoint,_currentDmg];
 
-//_damage
+//_damage;

--- a/ModSource/breakingpoint_functions/functions/Medical/fn_damageHandlerZ.sqf
+++ b/ModSource/breakingpoint_functions/functions/Medical/fn_damageHandlerZ.sqf
@@ -13,7 +13,7 @@ params ["_zed","_selection","_damage","_source","_projectile"];
 //_hitpoint = "HitBody";
 if (_selection == "head_hit") then { 
 //_hitpoint = "HitHead"; 
-_zed setDamage (0.7 + random 0.6);
+_zed setDamage (0.7 + random 0.7);
 };
 
 ["damageHandlerZ: Zed: %1 | Selection: %2 | Damage: %3 | Source: %4 | Projectile: %5",_zed,_selection,_damage,_source,_projectile] call BP_fnc_debugConsoleFormat;

--- a/ModSource/breakingpoint_infected/CfgMovesBPZombie1.hpp
+++ b/ModSource/breakingpoint_infected/CfgMovesBPZombie1.hpp
@@ -154,10 +154,10 @@ class CfgMovesBPZombie1 : CfgMovesAnimal_Base_F
 			soundEnabled = true;
 			canPullTrigger = false;
 			duty = -0.7;
-			relSpeedMin = 1.0;
-			relSpeedMax = 1.2;
+			relSpeedMin = 1.2;
+			relSpeedMax = 1.4;
 			walkcycles = 2;
-			speed = 0.910000;
+			speed = 1.110000;
 			looped = true;
 		};
 		
@@ -174,10 +174,10 @@ class CfgMovesBPZombie1 : CfgMovesAnimal_Base_F
 			soundEnabled = true;
 			canPullTrigger = false;
 			duty = -0.5;
-			relSpeedMin = 1.1;
-			relSpeedMax = 1.4;
+			relSpeedMin = 1.3;
+			relSpeedMax = 1.6;
 			walkcycles = 2;
-			speed = 1.22000;
+			speed = 1.42000;
 			onLandEnd = 1;
 			looped = true;
 			headBobStrength = 0.3;
@@ -200,10 +200,10 @@ class CfgMovesBPZombie1 : CfgMovesAnimal_Base_F
 			soundEnabled = true;
 			canPullTrigger = false;
 			duty = 0.5;
-			relSpeedMin = 1.5;
-			relSpeedMax = 1.6;
+			relSpeedMin = 2.5;
+			relSpeedMax = 2.6;
 			walkcycles = 2;
-			speed = 1.11;
+			speed = 2.11;
 			onLandEnd = 1;
 			looped = true;
 			static = 1;

--- a/ModSource/breakingpoint_infected/CfgMovesBPZombie1.hpp
+++ b/ModSource/breakingpoint_infected/CfgMovesBPZombie1.hpp
@@ -154,10 +154,10 @@ class CfgMovesBPZombie1 : CfgMovesAnimal_Base_F
 			soundEnabled = true;
 			canPullTrigger = false;
 			duty = -0.7;
-			relSpeedMin = 1.2;
-			relSpeedMax = 1.4;
+			relSpeedMin = 1.0;
+			relSpeedMax = 1.2;
 			walkcycles = 2;
-			speed = 1.110000;
+			speed = 0.910000;
 			looped = true;
 		};
 		
@@ -174,10 +174,10 @@ class CfgMovesBPZombie1 : CfgMovesAnimal_Base_F
 			soundEnabled = true;
 			canPullTrigger = false;
 			duty = -0.5;
-			relSpeedMin = 1.3;
-			relSpeedMax = 1.6;
+			relSpeedMin = 1.1;
+			relSpeedMax = 1.4;
 			walkcycles = 2;
-			speed = 1.42000;
+			speed = 1.22000;
 			onLandEnd = 1;
 			looped = true;
 			headBobStrength = 0.3;
@@ -200,10 +200,10 @@ class CfgMovesBPZombie1 : CfgMovesAnimal_Base_F
 			soundEnabled = true;
 			canPullTrigger = false;
 			duty = 0.5;
-			relSpeedMin = 2.5;
-			relSpeedMax = 2.6;
+			relSpeedMin = 1.5;
+			relSpeedMax = 1.6;
 			walkcycles = 2;
-			speed = 2.11;
+			speed = 1.11;
 			onLandEnd = 1;
 			looped = true;
 			static = 1;
@@ -319,5 +319,164 @@ class CfgMovesBPZombie1 : CfgMovesAnimal_Base_F
 		aimingUpLauncher[] = {"weapon", 1, "Camera", 1, "launcher", 1, "Head", 1, "Neck", 1, "Neck1", 1, "LeftShoulder", 1, "LeftArm", 1, "LeftArmRoll", 1, "LeftForeArm", 1, "LeftForeArmRoll", 1, "LeftHand", 1, "LeftHandRing", 1, "LeftHandPinky1", 1, "LeftHandPinky2", 1, "LeftHandPinky3", 1, "LeftHandRing1", 1, "LeftHandRing2", 1, "LeftHandRing3", 1, "LeftHandMiddle1", 1, "LeftHandMiddle2", 1, "LeftHandMiddle3", 1, "LeftHandIndex1", 1, "LeftHandIndex2", 1, "LeftHandIndex3", 1, "LeftHandThumb1", 1, "LeftHandThumb2", 1, "LeftHandThumb3", 1, "RightShoulder", 1, "RightArm", 1, "RightArmRoll", 1, "RightForeArm", 1, "RightForeArmRoll", 1, "RightHand", 1, "RightHandRing", 1, "RightHandPinky1", 1, "RightHandPinky2", 1, "RightHandPinky3", 1, "RightHandRing1", 1, "RightHandRing2", 1, "RightHandRing3", 1, "RightHandMiddle1", 1, "RightHandMiddle2", 1, "RightHandMiddle3", 1, "RightHandIndex1", 1, "RightHandIndex2", 1, "RightHandIndex3", 1, "RightHandThumb1", 1, "RightHandThumb2", 1, "RightHandThumb3", 1, "spine3", 0.95, "spine2", 0.9, "spine1", 0.8, "spine", 0.7};
 		legsDefault[] = {"LeftUpLeg", 0.9, "LeftUpLegRoll", 0.9, "LeftLeg", 0.95, "LeftLegRoll", 0.95, "LeftFoot", 1, "LeftToeBase", 1, "RightUpLeg", 0.9, "RightUpLegRoll", 0.9, "RightLeg", 0.95, "RightLegRoll", 0.95, "RightFoot", 1, "RightToeBase", 1};
 		idleDefault[] = {"Pelvis", 1, "Spine", 1, "Spine1", 1, "Spine2", 1, "Spine3", 1, "Camera", 1, "weapon", 1, "launcher", 1, "neck", 1, "neck1", 1, "head", 1, "LeftShoulder", 1, "LeftArm", 1, "LeftArmRoll", 1, "LeftForeArm", 1, "LeftForeArmRoll", 1, "LeftHand", 1, "LeftHandRing", 1, "LeftHandRing1", 1, "LeftHandRing2", 1, "LeftHandRing3", 1, "LeftHandPinky1", 1, "LeftHandPinky2", 1, "LeftHandPinky3", 1, "LeftHandMiddle1", 1, "LeftHandMiddle2", 1, "LeftHandMiddle3", 1, "LeftHandIndex1", 1, "LeftHandIndex2", 1, "LeftHandIndex3", 1, "LeftHandThumb1", 1, "LeftHandThumb2", 1, "LeftHandThumb3", 1, "RightShoulder", 1, "RightArm", 1, "RightArmRoll", 1, "RightForeArm", 1, "RightForeArmRoll", 1, "RightHand", 1, "RightHandRing", 1, "RightHandRing1", 1, "RightHandRing2", 1, "RightHandRing3", 1, "RightHandPinky1", 1, "RightHandPinky2", 1, "RightHandPinky3", 1, "RightHandMiddle1", 1, "RightHandMiddle2", 1, "RightHandMiddle3", 1, "RightHandIndex1", 1, "RightHandIndex2", 1, "RightHandIndex3", 1, "RightHandThumb1", 1, "RightHandThumb2", 1, "RightHandThumb3", 1, "LeftUpLeg", 1, "LeftUpLegRoll", 1, "LeftLeg", 1, "LeftLegRoll", 1, "LeftFoot", 1, "LeftToeBase", 1, "RightUpLeg", 1, "RightUpLegRoll", 1, "RightLeg", 1, "RightLegRoll", 1, "RightFoot", 1, "RightToeBase", 1};
+	};
+};
+class CfgMovesBPZombieImp1: CfgMovesBPZombie1
+{
+	class States
+	{
+		class Zombie_Stop: StandBase
+		{
+			enableDirectControl=1;
+			actions="BPZombieActions";
+			duty=-1;
+			file="\breakingpoint_anim\zmb\BP_Zombie_Runner_Idle.rtm";
+			connectTo[]=
+			{
+				"Zombie_Walk",
+				0.1,
+				"Zombie_Run",
+				0.1,
+				"Zombie_Sprint",
+				0.1
+			};
+			interpolateTo[]=
+			{
+				"Zombie_Die",
+				0.1,
+				"Zombie_Attack",
+				0.1,
+				"Zombie_Sprint",
+				0.1,
+				"Zombie_Run",
+				0.1,
+				"Zombie_Walk",
+				0.1,
+				"Zombie_Stop",
+				0.1
+			};
+			headBobStrength=0.30000001;
+			headBobMode=2;
+			canPullTrigger=0;
+			disableWeapons=1;
+			disableWeaponsLong=1;
+			enableOptics=0;
+			speed=0.090000004;
+			soundEnabled="false";
+			preload="true";
+			looped="true";
+			Walkcycles=2;
+			interpolationSpeed=1;
+			relSpeedMin=1.1;
+			relSpeedMax=1.1;
+		};
+		class Zombie_Walk: Zombie_Stop
+		{
+			actions="BPZombieWalk";
+			file="\breakingpoint_anim\zmb\BP_Zombie_Runner_Walk.rtm";
+			head="headDefault";
+			connectTo[]={};
+			soundOverride="walk";
+			soundEnabled="true";
+			canPullTrigger="false";
+			duty=-0.69999999;
+			relSpeedMin=1.2;
+			relSpeedMax=1.4;
+			walkcycles=2;
+			speed=1.11;
+			looped="true";
+		};
+		class Zombie_Run: Zombie_Stop
+		{
+			actions="BPZombieRun";
+			file="\breakingpoint_anim\zmb\BP_Zombie_Runner_Run.rtm";
+			head="headDefault";
+			connectTo[]={};
+			soundOverride="run";
+			soundEnabled="true";
+			canPullTrigger="false";
+			duty=-0.5;
+			relSpeedMin=1.3;
+			relSpeedMax=1.6;
+			walkcycles=2;
+			speed=1.42;
+			onLandEnd=1;
+			looped="true";
+			headBobStrength=0.30000001;
+			headBobMode=2;
+			enableDirectControl=0;
+			interpolationRestart=1;
+			interpolationSpeed=2.5;
+		};
+		class Zombie_Sprint: Zombie_Stop
+		{
+			actions="BPZombieSprint";
+			file="\breakingpoint_anim\zmb\BP_Zombie_Runner_Sprint_V3.rtm";
+			head="headDefault";
+			connectTo[]={};
+			interpolateTo[]=
+			{
+				"Zombie_Die",
+				0.050000001,
+				"Zombie_Attack",
+				0.050000001,
+				"Zombie_Sprint",
+				0.050000001
+			};
+			soundOverride="sprint";
+			soundEnabled="true";
+			canPullTrigger="false";
+			duty=0.5;
+			relSpeedMin=2.5;
+			relSpeedMax=2.6;
+			walkcycles=2;
+			speed=2.1099999;
+			onLandEnd=1;
+			looped="true";
+			static=1;
+			enableDirectControl=0;
+			interpolationRestart=1;
+			interpolationSpeed=2.5;
+		};
+		class Zombie_Attack: Zombie_Stop
+		{
+			actions="BPZombieActions";
+			file="\breakingpoint_anim\zmb\BPZombie2_Attack1.rtm";
+			speed=1.3;
+			soundEnabled=0;
+			interpolateTo[]=
+			{
+				"Zombie_Die",
+				0.02
+			};
+			looped="false";
+		};
+		class Zombie_Die: DefaultDie
+		{
+			file="\A3\anims_f\Data\Anim\Sdr\dth\pne\stp\ras\Rfl\AdthPpneMstpSrasWrflDnon_1";
+			speed=0.69999999;
+			looped=0;
+			onLandBeg=1;
+			onLandEnd=1;
+			soundEnabled=0;
+			ragdoll=1;
+			headBobMode=2;
+			disableWeapons=1;
+			disableWeaponsLong=1;
+			actions="NoActions";
+			variantsPlayer[]={};
+			variantsAI[]={};
+			variantAfter[]={0,0,0};
+			interpolateFrom[]=
+			{
+				"Zombie_Stop",
+				0.1,
+				"Zombie_Walk",
+				0.1,
+				"Zombie_Sprint",
+				0.1
+			};
+			terminal="true";
+		};
 	};
 };

--- a/ModSource/breakingpoint_infected/CfgMovesBPZombie2.hpp
+++ b/ModSource/breakingpoint_infected/CfgMovesBPZombie2.hpp
@@ -124,10 +124,10 @@ class CfgMovesBPZombie2 : CfgMovesAnimal_Base_F
 			soundEnabled = true;
 			canPullTrigger = false;
 			duty = -0.7;
-			relSpeedMin = 1.00;
-			relSpeedMax = 1.20;
+			relSpeedMin = 1.20;
+			relSpeedMax = 1.40;
 			walkcycles = 10;
-			speed = 0.82;
+			speed = 1.02;
 			looped = true;
 		};
 		
@@ -141,10 +141,10 @@ class CfgMovesBPZombie2 : CfgMovesAnimal_Base_F
 			soundEnabled = true;
 			canPullTrigger = false;
 			duty = 0.6;
-			relSpeedMin = 1.15;
-			relSpeedMax = 1.65;
+			relSpeedMin = 1.45;
+			relSpeedMax = 1.95;
 			walkcycles = 10;
-			speed = 1.07;
+			speed = 1.37;
 			onLandEnd = 1;
 			looped = true;
 			

--- a/ModSource/breakingpoint_infected/CfgMovesBPZombie2.hpp
+++ b/ModSource/breakingpoint_infected/CfgMovesBPZombie2.hpp
@@ -124,10 +124,10 @@ class CfgMovesBPZombie2 : CfgMovesAnimal_Base_F
 			soundEnabled = true;
 			canPullTrigger = false;
 			duty = -0.7;
-			relSpeedMin = 1.20;
-			relSpeedMax = 1.40;
+			relSpeedMin = 1.00;
+			relSpeedMax = 1.20;
 			walkcycles = 10;
-			speed = 1.02;
+			speed = 0.82;
 			looped = true;
 		};
 		
@@ -141,10 +141,10 @@ class CfgMovesBPZombie2 : CfgMovesAnimal_Base_F
 			soundEnabled = true;
 			canPullTrigger = false;
 			duty = 0.6;
-			relSpeedMin = 1.45;
-			relSpeedMax = 1.95;
+			relSpeedMin = 1.15;
+			relSpeedMax = 1.65;
 			walkcycles = 10;
-			speed = 1.37;
+			speed = 1.07;
 			onLandEnd = 1;
 			looped = true;
 			
@@ -256,3 +256,142 @@ class CfgMovesBPZombie2 : CfgMovesAnimal_Base_F
 		idleDefault[] = {"Pelvis", 1, "Spine", 1, "Spine1", 1, "Spine2", 1, "Spine3", 1, "Camera", 1, "weapon", 1, "launcher", 1, "neck", 1, "neck1", 1, "head", 1, "LeftShoulder", 1, "LeftArm", 1, "LeftArmRoll", 1, "LeftForeArm", 1, "LeftForeArmRoll", 1, "LeftHand", 1, "LeftHandRing", 1, "LeftHandRing1", 1, "LeftHandRing2", 1, "LeftHandRing3", 1, "LeftHandPinky1", 1, "LeftHandPinky2", 1, "LeftHandPinky3", 1, "LeftHandMiddle1", 1, "LeftHandMiddle2", 1, "LeftHandMiddle3", 1, "LeftHandIndex1", 1, "LeftHandIndex2", 1, "LeftHandIndex3", 1, "LeftHandThumb1", 1, "LeftHandThumb2", 1, "LeftHandThumb3", 1, "RightShoulder", 1, "RightArm", 1, "RightArmRoll", 1, "RightForeArm", 1, "RightForeArmRoll", 1, "RightHand", 1, "RightHandRing", 1, "RightHandRing1", 1, "RightHandRing2", 1, "RightHandRing3", 1, "RightHandPinky1", 1, "RightHandPinky2", 1, "RightHandPinky3", 1, "RightHandMiddle1", 1, "RightHandMiddle2", 1, "RightHandMiddle3", 1, "RightHandIndex1", 1, "RightHandIndex2", 1, "RightHandIndex3", 1, "RightHandThumb1", 1, "RightHandThumb2", 1, "RightHandThumb3", 1, "LeftUpLeg", 1, "LeftUpLegRoll", 1, "LeftLeg", 1, "LeftLegRoll", 1, "LeftFoot", 1, "LeftToeBase", 1, "RightUpLeg", 1, "RightUpLegRoll", 1, "RightLeg", 1, "RightLegRoll", 1, "RightFoot", 1, "RightToeBase", 1};
 	};
 };
+class CfgMovesBPZombieImp2: CfgMovesBPZombie2
+{
+	class States
+	{
+		class Zombie_Stop: StandBase
+		{
+			actions="BPZombieActions";
+			duty=-1;
+			file="\breakingpoint_anim\zmb\BPZombie2_Idle_Base.rtm";
+			connectTo[]=
+			{
+				"Zombie_Walk",
+				0.1,
+				"Zombie_Run",
+				0.1
+			};
+			connectFrom[]=
+			{
+				"Zombie_Walk",
+				0.1,
+				"Zombie_Run",
+				0.1
+			};
+			interpolateTo[]=
+			{
+				"Zombie_Die",
+				0.1,
+				"Zombie_Attack",
+				0.1,
+				"Zombie_Run",
+				0.1,
+				"Zombie_Walk",
+				0.1
+			};
+			canPullTrigger=1;
+			speed=0.64999998;
+			preload="true";
+			looped="true";
+			Walkcycles=1;
+		};
+		class Zombie_Walk: Zombie_Stop
+		{
+			actions="BPZombieActions";
+			file="\breakingpoint_anim\zmb\BPZombie2_Walk.rtm";
+			head="headDefault";
+			connectTo[]=
+			{
+				"Zombie_Stop",
+				0.1,
+				"Zombie_Run",
+				0.1
+			};
+			connectFrom[]=
+			{
+				"Zombie_Stop",
+				0.1,
+				"Zombie_Run",
+				0.1
+			};
+			soundOverride="sprint";
+			soundEnabled="true";
+			canPullTrigger="false";
+			duty=-0.7;
+			relSpeedMin=1.2;
+			relSpeedMax=1.4;
+			walkcycles=10;
+			speed=1.02;
+			looped="true";
+		};
+		class Zombie_Run: Zombie_Stop
+		{
+			actions="BPZombieActions";
+			file="\breakingpoint_anim\zmb\BPZombie2_Run.rtm";
+			head="headDefault";
+			connectTo[]=
+			{
+				"Zombie_Stop",
+				0.1,
+				"Zombie_Run",
+				0.1
+			};
+			connectFrom[]=
+			{
+				"Zombie_Stop",
+				0.1,
+				"Zombie_Run",
+				0.1
+			};
+			soundOverride="sprint";
+			soundEnabled="true";
+			canPullTrigger="false";
+			duty=0.60000002;
+			relSpeedMin=1.45;
+			relSpeedMax=1.95;
+			walkcycles=10;
+			speed=1.3700001;
+			onLandEnd=1;
+			looped="true";
+			enableDirectControl=0;
+			interpolationRestart=1;
+		};
+		class Zombie_Attack: Zombie_Stop
+		{
+			actions="BPZombieActions";
+			file="\breakingpoint_anim\zmb\BPZombie2_Attack.rtm";
+			speed=1;
+			soundOverride="";
+			soundEnabled=0;
+			interpolateTo[]=
+			{
+				"Zombie_Die",
+				0.1
+			};
+			looped="false";
+		};
+		class Zombie_Die: DefaultDie
+		{
+			file="\A3\anims_f\Data\Anim\Sdr\dth\pne\stp\ras\Rfl\AdthPpneMstpSrasWrflDnon_1";
+			speed=0.7;
+			looped=0;
+			onLandBeg=1;
+			onLandEnd=1;
+			soundEnabled=0;
+			ragdoll=1;
+			headBobMode=2;
+			disableWeapons=1;
+			disableWeaponsLong=1;
+			actions="NoActions";
+			variantsPlayer[]=
+			{
+				"Zombie_Die",
+				0.1
+			};
+			variantsAI[]={};
+			variantAfter[]={0,0,0};
+			terminal="true";
+		};
+	}; 
+	};

--- a/ModSource/breakingpoint_infected/CfgVehicles.hpp
+++ b/ModSource/breakingpoint_infected/CfgVehicles.hpp
@@ -24,328 +24,741 @@
 class CfgVehicles 
 {
 	class CAManBase;
-	class zZombie_Base : CAManBase 
+	class zZombie_Base: CAManBase
 	{
-		armor = 360; // total hit points (meaning global "health") of the object.
-		armorStructural = 0.4; // divides all damage taken to total hit point, either directly or through hit point passThrough coefficient. must be adjusted for each model to achieve consistent total damage results
-		explosionShielding = 0.04; // for consistent explosive damage after adjusting = ( armorStructural / 10 )
-		minTotalDamageThreshold	= 0.001; // minimalHit for total damage
-		impactDamageMultiplier = 0.5; // multiplier for falling damage
-		scope = private;
-		side = EAST;
-		modelSides[] = {NO_SIDE, EAST, WEST, CIVILIAN};
-		glassesEnabled = 0;
-		model = "\A3\characters_F\OPFOR\o_soldier_01.p3d";
-		vehicleClass = "Zombie";
-		displayName = "Zombie";
-		
-		//Zombie Move Animations
-		moves = "CfgMovesBPZombie1";
-       
-		//Vanilla FSMs
-		//fsmFormation = "Formation";
-		
-		//Custom FSMs
-		//fsmFormation = "breakingpoint_infected\scripts\formation.fsm";
-        //fsmDanger = "breakingpoint_infected\scripts\formationDanger.fsm";
-		
-		//Disable FSMs
-		fsmFormation = "";
-		fsmDanger = "";
-		
-		maxSpeed = 24;
-        formationX = 1;
-        formationZ = 1;
-        precision = 1;
-	
-		canHideBodies = 0;
-		canDeactivateMines = 0;
-		hideUnitInfo = 1;
-		enableGPS = 0;
-		isMan = false;
-		weapons[] = {};
-		magazines[] = {};
-		respawnWeapons[] = {};
-		respawnMagazines[] = {};
-		Items[] = {};
-		respawnItems[] = {};
-		linkedItems[] = {};
-		respawnlinkedItems[] = {};
-		sensitivity = 4;	// sensor sensitivity
-		sensitivityEar = 2;
-		faceType = "Man_A3";
-		identityTypes[] = {"BP_Zombie1"};
-		class TalkTopics {};
-		languages[] = {"EN"};
-
-		//Hidden Selection Textures
-		hiddenSelections[] = {"Camo1", "Camo2"};
-		hiddenSelectionsTextures[] = {"\breakingpoint_infected\textures\clothing\BP_Zombie_Clothes2.paa", "\A3\Characters_F\OPFOR\Data\tech_CO.paa"};
-
-		//Remove Zombies Making Normal Human Sounds on These Effects
-        class SoundEquipment {
+		scope=0;
+		side=0;
+		modelSides[]={-1,0,1,3};
+		glassesEnabled=0;
+		model="\A3\characters_F\OPFOR\o_soldier_01.p3d";
+		vehicleClass="Zombie";
+		displayName="Zombie";
+		moves="CfgMovesBPZombie1";
+		fsmFormation="";
+		fsmDanger="";
+		maxSpeed=24;
+		formationX=1;
+		formationZ=1;
+		precision=1;
+		canHideBodies=0;
+		canDeactivateMines=0;
+		hideUnitInfo=1;
+		enableGPS=0;
+		isMan="false";
+		weapons[]={};
+		magazines[]={};
+		respawnWeapons[]={};
+		respawnMagazines[]={};
+		Items[]={};
+		respawnItems[]={};
+		linkedItems[]={};
+		respawnlinkedItems[]={};
+		sensitivity=4;
+		sensitivityEar=2;
+		faceType="Man_A3";
+		identityTypes[]=
+		{
+			"BP_Zombie1"
+		};
+		class TalkTopics
+		{
+		};
+		languages[]=
+		{
+			"EN"
+		};
+		hiddenSelections[]=
+		{
+			"Camo1",
+			"Camo2"
+		};
+		hiddenSelectionsTextures[]=
+		{
+			"\breakingpoint_infected\textures\clothing\BP_Zombie_Clothes2.paa",
+			"\A3\Characters_F\OPFOR\Data\tech_CO.paa"
+		};
+		class SoundEquipment
+		{
 			civilian[]={};
 			soldier[]={};
 		};
-        class SoundGear {
+		class SoundGear
+		{
 			primary[]={};
 			secondary[]={};
 		};
-        class SoundBreath {
+		class SoundBreath
+		{
 			breath[]={};
 		};
-        class SoundDrown {
+		class SoundDrown
+		{
 			breath[]={};
-        };
-        class SoundInjured {
-			breath[]={};
-        };
-        class SoundBleeding {
-			breath[]={};
-        };
-        class SoundBurning {
-			breath[]={};
-        };
-        class SoundChoke {
-			breath[]={};
-        };
-        class SoundRecovered {
-			breath[]={};
-        };
-		
-		//Zombie Event Handlers
-		class Eventhandlers {
-			init = "_this call BP_fnc_zombieInitialize;";
-			local = "_this call BP_fnc_zombieLocal;";
-			handledamage = "_this call BP_fnc_damageHandlerZ;";
-			killed = "_this call BP_fnc_zombieKilled;";
 		};
-		
-		//Wounds / Blood Textures
-		class Wounds {
-			tex[] = {};
-			//mat[] = {};
-			//mat[] = {"\breakingpoint\textures\custom.rvmat", "\breakingpoint\textures\custom.rvmat", "\breakingpoint\textures\custom.rvmat"};
-			mat[] = {"A3\Characters_F\OPFOR\Data\clothing_injury.rvmat", "A3\Characters_F\OPFOR\Data\clothing_injury.rvmat", "A3\Characters_F\OPFOR\Data\clothing_injury.rvmat"};
+		class SoundInjured
+		{
+			breath[]={};
 		};
-		
-		//Hit Points / Damage
-		class HitPoints {
+		class SoundBleeding
+		{
+			breath[]={};
+		};
+		class SoundBurning
+		{
+			breath[]={};
+		};
+		class SoundChoke
+		{
+			breath[]={};
+		};
+		class SoundRecovered
+		{
+			breath[]={};
+		};
+		class Eventhandlers
+		{
+			init="_this call BP_fnc_zombieInitialize;";
+			local="_this call BP_fnc_zombieLocal;";
+			handledamage="_this call BP_fnc_damageHandlerZ;";
+			killed="_this call BP_fnc_zombieKilled;";
+		};
+		class Wounds
+		{
+			tex[]={};
+			mat[]=
+			{
+				"A3\Characters_F\OPFOR\Data\clothing_injury.rvmat",
+				"A3\Characters_F\OPFOR\Data\clothing_injury.rvmat",
+				"A3\Characters_F\OPFOR\Data\clothing_injury.rvmat"
+			};
+		};
+		class HitPoints
+		{
 			class HitHead
 			{
-				armor = 3.30000001;
+				armor=0.30000001;
 				material=-1;
-				minimalHit = 0.001;
-				passThrough = 0.01;
-				radius = 0.01;
 				name="head_hit";
-				//passThrough="true";
+				passThrough="true";
 				memoryPoint="pilot";
 			};
-			
 			class HitBody: HitHead
 			{
-				armor = 50;
-				minimalHit = 10;
-				passThrough = 0.001;
-				radius = 0.01;
+				armor=2;
 				name="body";
 				memoryPoint="aimPoint";
 			};
-			
 			class HitSpine: HitHead
 			{
-				armor = 50;
-				minimalHit = 10;
-				passThrough = 0.001;
-				radius = 0.01;
+				armor=2;
 				name="Spine2";
 				memoryPoint="aimPoint";
 			};
-			
 			class HitHands: HitHead
 			{
-				armor = 50.5;
-				minimalHit = 25;
-				passThrough = 0.001;
-				radius = 0.01;
+				armor=0.5;
 				material=-1;
 				name="hands";
-				//passThrough="true";
+				passThrough="true";
 			};
-			
-			class HitLArm : HitHands {
-				name = "LeftArm";
-				memoryPoint = "lelbow";
+			class HitLArm: HitHands
+			{
+				name="LeftArm";
+				memoryPoint="lelbow";
 			};
-			
-			class HitRArm : HitHands {
-				name = "RightArm";
-				memoryPoint = "relbow";
+			class HitRArm: HitHands
+			{
+				name="RightArm";
+				memoryPoint="relbow";
 			};
-			
-			class HitLForeArm : HitHands {
-				name = "LeftForeArm";
-				memoryPoint = "lwrist";
+			class HitLForeArm: HitHands
+			{
+				name="LeftForeArm";
+				memoryPoint="lwrist";
 			};
-			
-			class HitRForeArm : HitHands {
-				name = "RightForeArm";
-				memoryPoint = "rwrist";
+			class HitRForeArm: HitHands
+			{
+				name="RightForeArm";
+				memoryPoint="rwrist";
 			};
-			
-			class HitLHand : HitHands {
-				name = "LeftHand";
-				memoryPoint = "LeftHandMiddle1";
+			class HitLHand: HitHands
+			{
+				name="LeftHand";
+				memoryPoint="LeftHandMiddle1";
 			};
-			
-			class HitRHand : HitHands {
-				name = "RightHand";
-				memoryPoint = "RightHandMiddle1";
+			class HitRHand: HitHands
+			{
+				name="RightHand";
+				memoryPoint="RightHandMiddle1";
 			};
-			
-			class HitLegs : HitHands {
-				name = "legs";
-				memoryPoint = "pelvis";
+			class HitLegs: HitHands
+			{
+				name="legs";
+				memoryPoint="pelvis";
 			};
-			
-			class HitLLeg : HitHands {
-				name = "LeftLeg";
-				memoryPoint = "lknee";
+			class HitLLeg: HitHands
+			{
+				name="LeftLeg";
+				memoryPoint="lknee";
 			};
-			
-			class HitLLegUp : HitHands {
-				name = "LeftUpLeg";
-				memoryPoint = "lfemur";
+			class HitLLegUp: HitHands
+			{
+				name="LeftUpLeg";
+				memoryPoint="lfemur";
 			};
-			
-			class HitRLeg : HitHands {
-				name = "RightLeg";
-				memoryPoint = "rknee";
+			class HitRLeg: HitHands
+			{
+				name="RightLeg";
+				memoryPoint="rknee";
 			};
-			
-			class HitRLegUp : HitHands {
-				name = "RightUpLeg";
-				memoryPoint = "rfemur";
+			class HitRLegUp: HitHands
+			{
+				name="RightUpLeg";
+				memoryPoint="rfemur";
 			};
 		};
 	};
-	
-	class BPZombie_Rebel1 : zZombie_Base {
-		scope = protected;
-		model = "\breakingpoint_classes\models\BP_Rebel1.p3d";
-		hiddenSelections[] = {};
-		hiddenSelectionsTextures[] = {};
-		identityTypes[] = {"BP_Zombie1"};
+	class zZombie_Imp: zZombie_Base
+	{
+		armor=360;
+		armorStructural=0.40000001;
+		explosionShielding=0.039999999;
+		minTotalDamageThreshold=0.001;
+		impactDamageMultiplier=0.5;
+		moves="CfgMovesBPZombieImp1";
+	class HitPoints
+		{
+			class HitHead
+			{
+				armor=3.3;
+				material=-1;
+				minimalHit=0.001;
+				passThrough=0.0099999998;
+				radius=0.0099999998;
+				name="head_hit";
+				memoryPoint="pilot";
+			};
+			class HitBody: HitHead
+			{
+				armor=50;
+				minimalHit=10;
+				passThrough=0.001;
+				radius=0.0099999998;
+				name="body";
+				memoryPoint="aimPoint";
+			};
+			class HitSpine: HitHead
+			{
+				armor=50;
+				minimalHit=10;
+				passThrough=0.001;
+				radius=0.0099999998;
+				name="Spine2";
+				memoryPoint="aimPoint";
+			};
+			class HitHands: HitHead
+			{
+				armor=50.5;
+				minimalHit=25;
+				passThrough=0.001;
+				radius=0.0099999998;
+				material=-1;
+				name="hands";
+			};
+			class HitLArm: HitHands
+			{
+				name="LeftArm";
+				memoryPoint="lelbow";
+			};
+			class HitRArm: HitHands
+			{
+				name="RightArm";
+				memoryPoint="relbow";
+			};
+			class HitLForeArm: HitHands
+			{
+				name="LeftForeArm";
+				memoryPoint="lwrist";
+			};
+			class HitRForeArm: HitHands
+			{
+				name="RightForeArm";
+				memoryPoint="rwrist";
+			};
+			class HitLHand: HitHands
+			{
+				name="LeftHand";
+				memoryPoint="LeftHandMiddle1";
+			};
+			class HitRHand: HitHands
+			{
+				name="RightHand";
+				memoryPoint="RightHandMiddle1";
+			};
+			class HitLegs: HitHands
+			{
+				name="legs";
+				memoryPoint="pelvis";
+			};
+			class HitLLeg: HitHands
+			{
+				name="LeftLeg";
+				memoryPoint="lknee";
+			};
+			class HitLLegUp: HitHands
+			{
+				name="LeftUpLeg";
+				memoryPoint="lfemur";
+			};
+			class HitRLeg: HitHands
+			{
+				name="RightLeg";
+				memoryPoint="rknee";
+			};
+			class HitRLegUp: HitHands
+			{
+				name="RightUpLeg";
+				memoryPoint="rfemur";
+			};
+		};
 	};
-
-	class BPZombie_Rebel2 : zZombie_Base {
-		scope = protected;
-		model = "\breakingpoint_classes\models\BP_Rebel2.p3d";
-		hiddenSelections[] = {};
-		hiddenSelectionsTextures[] = {};
-		identityTypes[] = {"BP_Zombie1"};
+	class BPZombie_Rebel1: zZombie_Base
+	{
+		scope=1;
+		model="\breakingpoint_classes\models\BP_Rebel1.p3d";
+		hiddenSelections[]={};
+		hiddenSelectionsTextures[]={};
+		identityTypes[]=
+		{
+			"BP_Zombie1"
+		};
 	};
-	
-	class BPZombie_Rebel3 : zZombie_Base {
-		scope = protected;
-		model = "\breakingpoint_classes\models\BP_Rebel3.p3d";
-		hiddenSelections[] = {"Camo"};
-		hiddenSelectionsTextures[] = {"\breakingpoint\textures\clothing\loc_opfor01_1_co.paa"};
-		identityTypes[] = {"BP_Zombie2"};
-	};	
-
-	class BPZombie_Guardian1 : zZombie_Base {
-		scope = protected;
-		model = "\breakingpoint_classes\models\BP_Guardian1.p3d";
-		hiddenSelections[] = {"Camo"};
-		hiddenSelectionsTextures[] = {"breakingpoint\textures\clothing\gracenko_co.paa"};
-		identityTypes[] = {"BP_Zombie1"};
-	};	
-
-	class BPZombie_Guardian2 : zZombie_Base {
-		scope = protected;
-		model = "\breakingpoint_classes\models\BP_Guardian4.p3d";
-		hiddenSelections[] = {};
-		hiddenSelectionsTextures[] = {};
-		identityTypes[] = {"BP_Zombie1"};
+	class BPZombie_Rebel2: zZombie_Base
+	{
+		scope=1;
+		model="\breakingpoint_classes\models\BP_Rebel2.p3d";
+		hiddenSelections[]={};
+		hiddenSelectionsTextures[]={};
+		identityTypes[]=
+		{
+			"BP_Zombie1"
+		};
 	};
-
-	class BPZombie_Guardian3 : zZombie_Base {
-		scope = protected;
-		model = "\breakingpoint_classes\models\BP_Guardian3.p3d";
-		hiddenSelections[] = {};
-		hiddenSelectionsTextures[] = {};
-		identityTypes[] = {"BP_Zombie2"};
-	};		
-
-	class BPZombie_Survivalist1 : zZombie_Base {
-		scope = protected;
-		model = "\breakingpoint_classes\models\BP_Survivalist1.p3d";
-	    hiddenSelections[] = {};
-		hiddenSelectionsTextures[] = {};
-	    identityTypes[] = {"BP_Zombie1"};
+	class BPZombie_Rebel3: zZombie_Base
+	{
+		scope=1;
+		model="\breakingpoint_classes\models\BP_Rebel3.p3d";
+		hiddenSelections[]=
+		{
+			"Camo"
+		};
+		hiddenSelectionsTextures[]=
+		{
+			"\breakingpoint\textures\clothing\loc_opfor01_1_co.paa"
+		};
+		identityTypes[]=
+		{
+			"BP_Zombie2"
+		};
 	};
-
-	class BPZombie_Survivalist2 : zZombie_Base {
-		scope = protected;
-		model = "\breakingpoint_classes\models\BP_Survivalist2.p3d";
-		hiddenSelections[] = {"Camo"};
-		hiddenSelectionsTextures[] = {"\breakingpoint_classes\textures\ghillie_top_desert_co.paa"};
-		identityTypes[] = {"BP_Zombie1"};
+	class BPZombie_Guardian1: zZombie_Base
+	{
+		scope=1;
+		model="\breakingpoint_classes\models\BP_Guardian1.p3d";
+		hiddenSelections[]=
+		{
+			"Camo"
+		};
+		hiddenSelectionsTextures[]=
+		{
+			"breakingpoint\textures\clothing\gracenko_co.paa"
+		};
+		identityTypes[]=
+		{
+			"BP_Zombie1"
+		};
 	};
-
-	class BPZombie_Survivalist3 : zZombie_Base {
-		scope = protected;
-		model = "\breakingpoint_ghillie\models\ghilliegrass.p3d";
-		hiddenSelections[] = {"Camo"};
-		hiddenSelectionsTextures[] = {"\breakingpoint_ghillie\textures2\ghillie_4_co.paa"};
-		identityTypes[] = {"BP_Zombie2"};
+	class BPZombie_Guardian2: zZombie_Base
+	{
+		scope=1;
+		model="\breakingpoint_classes\models\BP_Guardian4.p3d";
+		hiddenSelections[]={};
+		hiddenSelectionsTextures[]={};
+		identityTypes[]=
+		{
+			"BP_Zombie1"
+		};
 	};
-	
-	class BPZombie_Refugee1 : zZombie_Base {
-		scope = protected;
-		model = "\breakingpoint_classes\models\BP_Refugee1.p3d";
-		hiddenSelections[] = {"Camo"};
-		hiddenSelectionsTextures[] = {"breakingpoint_classes\textures\overall_co.paa"};
-		identityTypes[] = {"BP_Zombie1"};
+	class BPZombie_Guardian3: zZombie_Base
+	{
+		scope=1;
+		model="\breakingpoint_classes\models\BP_Guardian3.p3d";
+		hiddenSelections[]={};
+		hiddenSelectionsTextures[]={};
+		identityTypes[]=
+		{
+			"BP_Zombie2"
+		};
 	};
-
-	class BPZombie_Refugee2 : zZombie_Base {
-		scope = protected;
-		model = "\breakingpoint_classes\models\BP_Refugee2.p3d";
-		hiddenSelections[] = {"Camo"};
-		hiddenSelectionsTextures[] = {"breakingpoint\textures\clothing\worker_co.paa"};
-		identityTypes[] = {"BP_Zombie1"};
+	class BPZombie_Survivalist1: zZombie_Base
+	{
+		scope=1;
+		model="\breakingpoint_classes\models\BP_Survivalist1.p3d";
+		hiddenSelections[]={};
+		hiddenSelectionsTextures[]={};
+		identityTypes[]=
+		{
+			"BP_Zombie1"
+		};
 	};
-
-	class BPZombie_Refugee3 : zZombie_Base {
-		scope = protected;
-		model = "\breakingpoint_classes\models\BP_Refugee3.p3d";
-		hiddenSelections[] = {};
-		hiddenSelectionsTextures[] = {};
-		identityTypes[] = {"BP_Zombie2"};
+	class BPZombie_Survivalist2: zZombie_Base
+	{
+		scope=1;
+		model="\breakingpoint_classes\models\BP_Survivalist2.p3d";
+		hiddenSelections[]=
+		{
+			"Camo"
+		};
+		hiddenSelectionsTextures[]=
+		{
+			"\breakingpoint_classes\textures\ghillie_top_desert_co.paa"
+		};
+		identityTypes[]=
+		{
+			"BP_Zombie1"
+		};
 	};
-	class BPZombie_Hunter1 : zZombie_Base {
-		scope = protected;
-		model = "\breakingpoint_classes\models\BP_Hunter1.p3d";
-		hiddenSelections[] = {"Camo1"};
-		hiddenSelectionsTextures[] = {"breakingpoint_classes\textures\acr_soldier_nic_co.paa"};
-		identityTypes[] = {"BP_Zombie1"};
+	class BPZombie_Survivalist3: zZombie_Base
+	{
+		scope=1;
+		model="\breakingpoint_ghillie\models\ghilliegrass.p3d";
+		hiddenSelections[]=
+		{
+			"Camo"
+		};
+		hiddenSelectionsTextures[]=
+		{
+			"\breakingpoint_ghillie\textures2\ghillie_4_co.paa"
+		};
+		identityTypes[]=
+		{
+			"BP_Zombie2"
+		};
 	};
-	class BPZombie_Hunter2 : zZombie_Base {
-		scope = protected;
-		model = "\breakingpoint_classes\models\BP_Hunter2.p3d";
-		hiddenSelections[] = {"Camo1"};
-		hiddenSelectionsTextures[] = {"breakingpoint_classes\textures\acr_soldier_nic_co.paa"};
-		identityTypes[] = {"BP_Zombie1"};
+	class BPZombie_Refugee1: zZombie_Base
+	{
+		scope=1;
+		model="\breakingpoint_classes\models\BP_Refugee1.p3d";
+		hiddenSelections[]=
+		{
+			"Camo"
+		};
+		hiddenSelectionsTextures[]=
+		{
+			"breakingpoint_classes\textures\overall_co.paa"
+		};
+		identityTypes[]=
+		{
+			"BP_Zombie1"
+		};
 	};
-	class BPZombie_Hunter3 : zZombie_Base {
-		scope = protected;
-		model = "\breakingpoint_classes\models\BP_Hunter3.p3d";
-		hiddenSelections[] = {"Camo1"};
-		hiddenSelectionsTextures[] = {"breakingpoint_classes\textures\acr_soldier_nic_co.paa"};
-		identityTypes[] = {"BP_Zombie2"};
+	class BPZombie_Refugee2: zZombie_Base
+	{
+		scope=1;
+		model="\breakingpoint_classes\models\BP_Refugee2.p3d";
+		hiddenSelections[]=
+		{
+			"Camo"
+		};
+		hiddenSelectionsTextures[]=
+		{
+			"breakingpoint\textures\clothing\worker_co.paa"
+		};
+		identityTypes[]=
+		{
+			"BP_Zombie1"
+		};
+	};
+	class BPZombie_Refugee3: zZombie_Base
+	{
+		scope=1;
+		model="\breakingpoint_classes\models\BP_Refugee3.p3d";
+		hiddenSelections[]={};
+		hiddenSelectionsTextures[]={};
+		identityTypes[]=
+		{
+			"BP_Zombie2"
+		};
+	};
+	class BPZombie_Hunter1: zZombie_Base
+	{
+		scope=1;
+		model="\breakingpoint_classes\models\BP_Hunter1.p3d";
+		hiddenSelections[]=
+		{
+			"Camo1"
+		};
+		hiddenSelectionsTextures[]=
+		{
+			"breakingpoint_classes\textures\acr_soldier_nic_co.paa"
+		};
+		identityTypes[]=
+		{
+			"BP_Zombie1"
+		};
+	};
+	class BPZombie_Hunter2: zZombie_Base
+	{
+		scope=1;
+		model="\breakingpoint_classes\models\BP_Hunter2.p3d";
+		hiddenSelections[]=
+		{
+			"Camo1"
+		};
+		hiddenSelectionsTextures[]=
+		{
+			"breakingpoint_classes\textures\acr_soldier_nic_co.paa"
+		};
+		identityTypes[]=
+		{
+			"BP_Zombie1"
+		};
+	};
+	class BPZombie_Hunter3: zZombie_Base
+	{
+		scope=1;
+		model="\breakingpoint_classes\models\BP_Hunter3.p3d";
+		hiddenSelections[]=
+		{
+			"Camo1"
+		};
+		hiddenSelectionsTextures[]=
+		{
+			"breakingpoint_classes\textures\acr_soldier_nic_co.paa"
+		};
+		identityTypes[]=
+		{
+			"BP_Zombie2"
+		};
+	};
+	class BPZombie_RebelImp1: zZombie_Imp
+	{
+		scope=1;
+		model="\breakingpoint_classes\models\BP_Rebel1.p3d";
+		hiddenSelections[]={};
+		hiddenSelectionsTextures[]={};
+		identityTypes[]=
+		{
+			"BP_Zombie1"
+		};
+	};
+	class BPZombie_RebelImp2: zZombie_Imp
+	{
+		scope=1;
+		model="\breakingpoint_classes\models\BP_Rebel2.p3d";
+		hiddenSelections[]={};
+		hiddenSelectionsTextures[]={};
+		identityTypes[]=
+		{
+			"BP_Zombie1"
+		};
+	};
+	class BPZombie_RebelImp3: zZombie_Imp
+	{
+		scope=1;
+		model="\breakingpoint_classes\models\BP_Rebel3.p3d";
+		hiddenSelections[]=
+		{
+			"Camo"
+		};
+		hiddenSelectionsTextures[]=
+		{
+			"\breakingpoint\textures\clothing\loc_opfor01_1_co.paa"
+		};
+		identityTypes[]=
+		{
+			"BP_Zombie2"
+		};
+	};
+	class BPZombie_GuardianImp1: zZombie_Imp
+	{
+		scope=1;
+		model="\breakingpoint_classes\models\BP_Guardian1.p3d";
+		hiddenSelections[]=
+		{
+			"Camo"
+		};
+		hiddenSelectionsTextures[]=
+		{
+			"breakingpoint\textures\clothing\gracenko_co.paa"
+		};
+		identityTypes[]=
+		{
+			"BP_Zombie1"
+		};
+	};
+	class BPZombie_GuardianImp2: zZombie_Imp
+	{
+		scope=1;
+		model="\breakingpoint_classes\models\BP_Guardian4.p3d";
+		hiddenSelections[]={};
+		hiddenSelectionsTextures[]={};
+		identityTypes[]=
+		{
+			"BP_Zombie1"
+		};
+	};
+	class BPZombie_GuardianImp3: zZombie_Imp
+	{
+		scope=1;
+		model="\breakingpoint_classes\models\BP_Guardian3.p3d";
+		hiddenSelections[]={};
+		hiddenSelectionsTextures[]={};
+		identityTypes[]=
+		{
+			"BP_Zombie2"
+		};
+	};
+	class BPZombie_SurvivalistImp1: zZombie_Imp
+	{
+		scope=1;
+		model="\breakingpoint_classes\models\BP_Survivalist1.p3d";
+		hiddenSelections[]={};
+		hiddenSelectionsTextures[]={};
+		identityTypes[]=
+		{
+			"BP_Zombie1"
+		};
+	};
+	class BPZombie_SurvivalistImp2: zZombie_Imp
+	{
+		scope=1;
+		model="\breakingpoint_classes\models\BP_Survivalist2.p3d";
+		hiddenSelections[]=
+		{
+			"Camo"
+		};
+		hiddenSelectionsTextures[]=
+		{
+			"\breakingpoint_classes\textures\ghillie_top_desert_co.paa"
+		};
+		identityTypes[]=
+		{
+			"BP_Zombie1"
+		};
+	};
+	class BPZombie_SurvivalistImp3: zZombie_Imp
+	{
+		scope=1;
+		model="\breakingpoint_ghillie\models\ghilliegrass.p3d";
+		hiddenSelections[]=
+		{
+			"Camo"
+		};
+		hiddenSelectionsTextures[]=
+		{
+			"\breakingpoint_ghillie\textures2\ghillie_4_co.paa"
+		};
+		identityTypes[]=
+		{
+			"BP_Zombie2"
+		};
+	};
+	class BPZombie_RefugeeImp1: zZombie_Imp
+	{
+		scope=1;
+		model="\breakingpoint_classes\models\BP_Refugee1.p3d";
+		hiddenSelections[]=
+		{
+			"Camo"
+		};
+		hiddenSelectionsTextures[]=
+		{
+			"breakingpoint_classes\textures\overall_co.paa"
+		};
+		identityTypes[]=
+		{
+			"BP_Zombie1"
+		};
+	};
+	class BPZombie_RefugeeImp2: zZombie_Imp
+	{
+		scope=1;
+		model="\breakingpoint_classes\models\BP_Refugee2.p3d";
+		hiddenSelections[]=
+		{
+			"Camo"
+		};
+		hiddenSelectionsTextures[]=
+		{
+			"breakingpoint\textures\clothing\worker_co.paa"
+		};
+		identityTypes[]=
+		{
+			"BP_Zombie1"
+		};
+	};
+	class BPZombie_RefugeeImp3: zZombie_Imp
+	{
+		scope=1;
+		model="\breakingpoint_classes\models\BP_Refugee3.p3d";
+		hiddenSelections[]={};
+		hiddenSelectionsTextures[]={};
+		identityTypes[]=
+		{
+			"BP_Zombie2"
+		};
+	};
+	class BPZombie_HunterImp1: zZombie_Imp
+	{
+		scope=1;
+		model="\breakingpoint_classes\models\BP_Hunter1.p3d";
+		hiddenSelections[]=
+		{
+			"Camo1"
+		};
+		hiddenSelectionsTextures[]=
+		{
+			"breakingpoint_classes\textures\acr_soldier_nic_co.paa"
+		};
+		identityTypes[]=
+		{
+			"BP_Zombie1"
+		};
+	};
+	class BPZombie_HunterImp2: zZombie_Imp
+	{
+		scope=1;
+		model="\breakingpoint_classes\models\BP_Hunter2.p3d";
+		hiddenSelections[]=
+		{
+			"Camo1"
+		};
+		hiddenSelectionsTextures[]=
+		{
+			"breakingpoint_classes\textures\acr_soldier_nic_co.paa"
+		};
+		identityTypes[]=
+		{
+			"BP_Zombie1"
+		};
+	};
+	class BPZombie_HunterImp3: zZombie_Imp
+	{
+		scope=1;
+		model="\breakingpoint_classes\models\BP_Hunter3.p3d";
+		hiddenSelections[]=
+		{
+			"Camo1"
+		};
+		hiddenSelectionsTextures[]=
+		{
+			"breakingpoint_classes\textures\acr_soldier_nic_co.paa"
+		};
+		identityTypes[]=
+		{
+			"BP_Zombie2"
+		};
 	};
 };
 

--- a/ModSource/breakingpoint_infected/CfgVehicles.hpp
+++ b/ModSource/breakingpoint_infected/CfgVehicles.hpp
@@ -24,197 +24,188 @@
 class CfgVehicles 
 {
 	class CAManBase;
-	class zZombie_Base: CAManBase
+	class zZombie_Base : CAManBase 
 	{
-		scope=0;
-		side=0;
-		modelSides[]={-1,0,1,3};
-		glassesEnabled=0;
-		model="\A3\characters_F\OPFOR\o_soldier_01.p3d";
-		vehicleClass="Zombie";
-		displayName="Zombie";
-		moves="CfgMovesBPZombie1";
-		fsmFormation="";
-		fsmDanger="";
-		maxSpeed=24;
-		formationX=1;
-		formationZ=1;
-		precision=1;
-		canHideBodies=0;
-		canDeactivateMines=0;
-		hideUnitInfo=1;
-		enableGPS=0;
-		isMan="false";
-		weapons[]={};
-		magazines[]={};
-		respawnWeapons[]={};
-		respawnMagazines[]={};
-		Items[]={};
-		respawnItems[]={};
-		linkedItems[]={};
-		respawnlinkedItems[]={};
-		sensitivity=4;
-		sensitivityEar=2;
-		faceType="Man_A3";
-		identityTypes[]=
-		{
-			"BP_Zombie1"
-		};
-		class TalkTopics
-		{
-		};
-		languages[]=
-		{
-			"EN"
-		};
-		hiddenSelections[]=
-		{
-			"Camo1",
-			"Camo2"
-		};
-		hiddenSelectionsTextures[]=
-		{
-			"\breakingpoint_infected\textures\clothing\BP_Zombie_Clothes2.paa",
-			"\A3\Characters_F\OPFOR\Data\tech_CO.paa"
-		};
-		class SoundEquipment
-		{
+		scope = private;
+		side = EAST;
+		modelSides[] = {NO_SIDE, EAST, WEST, CIVILIAN};
+		glassesEnabled = 0;
+		model = "\A3\characters_F\OPFOR\o_soldier_01.p3d";
+		vehicleClass = "Zombie";
+		displayName = "Zombie";
+		
+		//Zombie Move Animations
+		moves = "CfgMovesBPZombie1";
+       
+		//Vanilla FSMs
+		//fsmFormation = "Formation";
+		
+		//Custom FSMs
+		//fsmFormation = "breakingpoint_infected\scripts\formation.fsm";
+        //fsmDanger = "breakingpoint_infected\scripts\formationDanger.fsm";
+		
+		//Disable FSMs
+		fsmFormation = "";
+		fsmDanger = "";
+		
+		maxSpeed = 24;
+        formationX = 1;
+        formationZ = 1;
+        precision = 1;
+	
+		canHideBodies = 0;
+		canDeactivateMines = 0;
+		hideUnitInfo = 1;
+		enableGPS = 0;
+		isMan = false;
+		weapons[] = {};
+		magazines[] = {};
+		respawnWeapons[] = {};
+		respawnMagazines[] = {};
+		Items[] = {};
+		respawnItems[] = {};
+		linkedItems[] = {};
+		respawnlinkedItems[] = {};
+		sensitivity = 4;	// sensor sensitivity
+		sensitivityEar = 2;
+		faceType = "Man_A3";
+		identityTypes[] = {"BP_Zombie1"};
+		class TalkTopics {};
+		languages[] = {"EN"};
+
+		//Hidden Selection Textures
+		hiddenSelections[] = {"Camo1", "Camo2"};
+		hiddenSelectionsTextures[] = {"\breakingpoint_infected\textures\clothing\BP_Zombie_Clothes2.paa", "\A3\Characters_F\OPFOR\Data\tech_CO.paa"};
+
+		//Remove Zombies Making Normal Human Sounds on These Effects
+        class SoundEquipment {
 			civilian[]={};
 			soldier[]={};
 		};
-		class SoundGear
-		{
+        class SoundGear {
 			primary[]={};
 			secondary[]={};
 		};
-		class SoundBreath
-		{
+        class SoundBreath {
 			breath[]={};
 		};
-		class SoundDrown
-		{
+        class SoundDrown {
 			breath[]={};
-		};
-		class SoundInjured
-		{
+        };
+        class SoundInjured {
 			breath[]={};
-		};
-		class SoundBleeding
-		{
+        };
+        class SoundBleeding {
 			breath[]={};
-		};
-		class SoundBurning
-		{
+        };
+        class SoundBurning {
 			breath[]={};
-		};
-		class SoundChoke
-		{
+        };
+        class SoundChoke {
 			breath[]={};
-		};
-		class SoundRecovered
-		{
+        };
+        class SoundRecovered {
 			breath[]={};
+        };
+		
+		//Zombie Event Handlers
+		class Eventhandlers {
+			init = "_this call BP_fnc_zombieInitialize;";
+			local = "_this call BP_fnc_zombieLocal;";
+			handledamage = "_this call BP_fnc_damageHandlerZ;";
+			killed = "_this call BP_fnc_zombieKilled;";
 		};
-		class Eventhandlers
-		{
-			init="_this call BP_fnc_zombieInitialize;";
-			local="_this call BP_fnc_zombieLocal;";
-			handledamage="_this call BP_fnc_damageHandlerZ;";
-			killed="_this call BP_fnc_zombieKilled;";
+		
+		//Wounds / Blood Textures
+		class Wounds {
+			tex[] = {};
+			//mat[] = {};
+			//mat[] = {"\breakingpoint\textures\custom.rvmat", "\breakingpoint\textures\custom.rvmat", "\breakingpoint\textures\custom.rvmat"};
+			mat[] = {"A3\Characters_F\OPFOR\Data\clothing_injury.rvmat", "A3\Characters_F\OPFOR\Data\clothing_injury.rvmat", "A3\Characters_F\OPFOR\Data\clothing_injury.rvmat"};
 		};
-		class Wounds
-		{
-			tex[]={};
-			mat[]=
-			{
-				"A3\Characters_F\OPFOR\Data\clothing_injury.rvmat",
-				"A3\Characters_F\OPFOR\Data\clothing_injury.rvmat",
-				"A3\Characters_F\OPFOR\Data\clothing_injury.rvmat"
+		
+		//Hit Points / Damage
+		class HitPoints {
+			class HitHead {
+				armor = 0.3;
+				material = -1;
+				name = "head_hit";
+				passThrough = true;
+				memoryPoint = "pilot";
 			};
-		};
-		class HitPoints
-		{
-			class HitHead
-			{
-				armor=0.30000001;
-				material=-1;
-				name="head_hit";
-				passThrough="true";
-				memoryPoint="pilot";
+			
+			class HitBody : HitHead {
+				armor = 2;
+				name = "body";
+				memoryPoint = "aimPoint";
 			};
-			class HitBody: HitHead
-			{
-				armor=2;
-				name="body";
-				memoryPoint="aimPoint";
+			
+			class HitSpine : HitHead {
+				armor = 2;
+				name = "Spine2";
+				memoryPoint = "aimPoint";
 			};
-			class HitSpine: HitHead
-			{
-				armor=2;
-				name="Spine2";
-				memoryPoint="aimPoint";
+			
+			class HitHands : HitHead {
+				armor = 0.5;
+				material = -1;
+				name = "hands";
+				passThrough = true;
 			};
-			class HitHands: HitHead
-			{
-				armor=0.5;
-				material=-1;
-				name="hands";
-				passThrough="true";
+			
+			class HitLArm : HitHands {
+				name = "LeftArm";
+				memoryPoint = "lelbow";
 			};
-			class HitLArm: HitHands
-			{
-				name="LeftArm";
-				memoryPoint="lelbow";
+			
+			class HitRArm : HitHands {
+				name = "RightArm";
+				memoryPoint = "relbow";
 			};
-			class HitRArm: HitHands
-			{
-				name="RightArm";
-				memoryPoint="relbow";
+			
+			class HitLForeArm : HitHands {
+				name = "LeftForeArm";
+				memoryPoint = "lwrist";
 			};
-			class HitLForeArm: HitHands
-			{
-				name="LeftForeArm";
-				memoryPoint="lwrist";
+			
+			class HitRForeArm : HitHands {
+				name = "RightForeArm";
+				memoryPoint = "rwrist";
 			};
-			class HitRForeArm: HitHands
-			{
-				name="RightForeArm";
-				memoryPoint="rwrist";
+			
+			class HitLHand : HitHands {
+				name = "LeftHand";
+				memoryPoint = "LeftHandMiddle1";
 			};
-			class HitLHand: HitHands
-			{
-				name="LeftHand";
-				memoryPoint="LeftHandMiddle1";
+			
+			class HitRHand : HitHands {
+				name = "RightHand";
+				memoryPoint = "RightHandMiddle1";
 			};
-			class HitRHand: HitHands
-			{
-				name="RightHand";
-				memoryPoint="RightHandMiddle1";
+			
+			class HitLegs : HitHands {
+				name = "legs";
+				memoryPoint = "pelvis";
 			};
-			class HitLegs: HitHands
-			{
-				name="legs";
-				memoryPoint="pelvis";
+			
+			class HitLLeg : HitHands {
+				name = "LeftLeg";
+				memoryPoint = "lknee";
 			};
-			class HitLLeg: HitHands
-			{
-				name="LeftLeg";
-				memoryPoint="lknee";
+			
+			class HitLLegUp : HitHands {
+				name = "LeftUpLeg";
+				memoryPoint = "lfemur";
 			};
-			class HitLLegUp: HitHands
-			{
-				name="LeftUpLeg";
-				memoryPoint="lfemur";
+			
+			class HitRLeg : HitHands {
+				name = "RightLeg";
+				memoryPoint = "rknee";
 			};
-			class HitRLeg: HitHands
-			{
-				name="RightLeg";
-				memoryPoint="rknee";
-			};
-			class HitRLegUp: HitHands
-			{
-				name="RightUpLeg";
-				memoryPoint="rfemur";
+			
+			class HitRLegUp : HitHands {
+				name = "RightUpLeg";
+				memoryPoint = "rfemur";
 			};
 		};
 	};
@@ -226,7 +217,7 @@ class CfgVehicles
 		minTotalDamageThreshold=0.001;
 		impactDamageMultiplier=0.5;
 		moves="CfgMovesBPZombieImp1";
-	class HitPoints
+		class HitPoints
 		{
 			class HitHead
 			{
@@ -322,224 +313,122 @@ class CfgVehicles
 			};
 		};
 	};
-	class BPZombie_Rebel1: zZombie_Base
-	{
-		scope=1;
-		model="\breakingpoint_classes\models\BP_Rebel1.p3d";
-		hiddenSelections[]={};
-		hiddenSelectionsTextures[]={};
-		identityTypes[]=
-		{
-			"BP_Zombie1"
-		};
+	
+	class BPZombie_Rebel1 : zZombie_Base {
+		scope = protected;
+		model = "\breakingpoint_classes\models\BP_Rebel1.p3d";
+		hiddenSelections[] = {};
+		hiddenSelectionsTextures[] = {};
+		identityTypes[] = {"BP_Zombie1"};
 	};
-	class BPZombie_Rebel2: zZombie_Base
-	{
-		scope=1;
-		model="\breakingpoint_classes\models\BP_Rebel2.p3d";
-		hiddenSelections[]={};
-		hiddenSelectionsTextures[]={};
-		identityTypes[]=
-		{
-			"BP_Zombie1"
-		};
+
+	class BPZombie_Rebel2 : zZombie_Base {
+		scope = protected;
+		model = "\breakingpoint_classes\models\BP_Rebel2.p3d";
+		hiddenSelections[] = {};
+		hiddenSelectionsTextures[] = {};
+		identityTypes[] = {"BP_Zombie1"};
 	};
-	class BPZombie_Rebel3: zZombie_Base
-	{
-		scope=1;
-		model="\breakingpoint_classes\models\BP_Rebel3.p3d";
-		hiddenSelections[]=
-		{
-			"Camo"
-		};
-		hiddenSelectionsTextures[]=
-		{
-			"\breakingpoint\textures\clothing\loc_opfor01_1_co.paa"
-		};
-		identityTypes[]=
-		{
-			"BP_Zombie2"
-		};
+	
+	class BPZombie_Rebel3 : zZombie_Base {
+		scope = protected;
+		model = "\breakingpoint_classes\models\BP_Rebel3.p3d";
+		hiddenSelections[] = {"Camo"};
+		hiddenSelectionsTextures[] = {"\breakingpoint\textures\clothing\loc_opfor01_1_co.paa"};
+		identityTypes[] = {"BP_Zombie2"};
+	};	
+
+	class BPZombie_Guardian1 : zZombie_Base {
+		scope = protected;
+		model = "\breakingpoint_classes\models\BP_Guardian1.p3d";
+		hiddenSelections[] = {"Camo"};
+		hiddenSelectionsTextures[] = {"breakingpoint\textures\clothing\gracenko_co.paa"};
+		identityTypes[] = {"BP_Zombie1"};
+	};	
+
+	class BPZombie_Guardian2 : zZombie_Base {
+		scope = protected;
+		model = "\breakingpoint_classes\models\BP_Guardian4.p3d";
+		hiddenSelections[] = {};
+		hiddenSelectionsTextures[] = {};
+		identityTypes[] = {"BP_Zombie1"};
 	};
-	class BPZombie_Guardian1: zZombie_Base
-	{
-		scope=1;
-		model="\breakingpoint_classes\models\BP_Guardian1.p3d";
-		hiddenSelections[]=
-		{
-			"Camo"
-		};
-		hiddenSelectionsTextures[]=
-		{
-			"breakingpoint\textures\clothing\gracenko_co.paa"
-		};
-		identityTypes[]=
-		{
-			"BP_Zombie1"
-		};
+
+	class BPZombie_Guardian3 : zZombie_Base {
+		scope = protected;
+		model = "\breakingpoint_classes\models\BP_Guardian3.p3d";
+		hiddenSelections[] = {};
+		hiddenSelectionsTextures[] = {};
+		identityTypes[] = {"BP_Zombie2"};
+	};		
+
+	class BPZombie_Survivalist1 : zZombie_Base {
+		scope = protected;
+		model = "\breakingpoint_classes\models\BP_Survivalist1.p3d";
+	    hiddenSelections[] = {};
+		hiddenSelectionsTextures[] = {};
+	    identityTypes[] = {"BP_Zombie1"};
 	};
-	class BPZombie_Guardian2: zZombie_Base
-	{
-		scope=1;
-		model="\breakingpoint_classes\models\BP_Guardian4.p3d";
-		hiddenSelections[]={};
-		hiddenSelectionsTextures[]={};
-		identityTypes[]=
-		{
-			"BP_Zombie1"
-		};
+
+	class BPZombie_Survivalist2 : zZombie_Base {
+		scope = protected;
+		model = "\breakingpoint_classes\models\BP_Survivalist2.p3d";
+		hiddenSelections[] = {"Camo"};
+		hiddenSelectionsTextures[] = {"\breakingpoint_classes\textures\ghillie_top_desert_co.paa"};
+		identityTypes[] = {"BP_Zombie1"};
 	};
-	class BPZombie_Guardian3: zZombie_Base
-	{
-		scope=1;
-		model="\breakingpoint_classes\models\BP_Guardian3.p3d";
-		hiddenSelections[]={};
-		hiddenSelectionsTextures[]={};
-		identityTypes[]=
-		{
-			"BP_Zombie2"
-		};
+
+	class BPZombie_Survivalist3 : zZombie_Base {
+		scope = protected;
+		model = "\breakingpoint_ghillie\models\ghilliegrass.p3d";
+		hiddenSelections[] = {"Camo"};
+		hiddenSelectionsTextures[] = {"\breakingpoint_ghillie\textures2\ghillie_4_co.paa"};
+		identityTypes[] = {"BP_Zombie2"};
 	};
-	class BPZombie_Survivalist1: zZombie_Base
-	{
-		scope=1;
-		model="\breakingpoint_classes\models\BP_Survivalist1.p3d";
-		hiddenSelections[]={};
-		hiddenSelectionsTextures[]={};
-		identityTypes[]=
-		{
-			"BP_Zombie1"
-		};
+	
+	class BPZombie_Refugee1 : zZombie_Base {
+		scope = protected;
+		model = "\breakingpoint_classes\models\BP_Refugee1.p3d";
+		hiddenSelections[] = {"Camo"};
+		hiddenSelectionsTextures[] = {"breakingpoint_classes\textures\overall_co.paa"};
+		identityTypes[] = {"BP_Zombie1"};
 	};
-	class BPZombie_Survivalist2: zZombie_Base
-	{
-		scope=1;
-		model="\breakingpoint_classes\models\BP_Survivalist2.p3d";
-		hiddenSelections[]=
-		{
-			"Camo"
-		};
-		hiddenSelectionsTextures[]=
-		{
-			"\breakingpoint_classes\textures\ghillie_top_desert_co.paa"
-		};
-		identityTypes[]=
-		{
-			"BP_Zombie1"
-		};
+
+	class BPZombie_Refugee2 : zZombie_Base {
+		scope = protected;
+		model = "\breakingpoint_classes\models\BP_Refugee2.p3d";
+		hiddenSelections[] = {"Camo"};
+		hiddenSelectionsTextures[] = {"breakingpoint\textures\clothing\worker_co.paa"};
+		identityTypes[] = {"BP_Zombie1"};
 	};
-	class BPZombie_Survivalist3: zZombie_Base
-	{
-		scope=1;
-		model="\breakingpoint_ghillie\models\ghilliegrass.p3d";
-		hiddenSelections[]=
-		{
-			"Camo"
-		};
-		hiddenSelectionsTextures[]=
-		{
-			"\breakingpoint_ghillie\textures2\ghillie_4_co.paa"
-		};
-		identityTypes[]=
-		{
-			"BP_Zombie2"
-		};
+
+	class BPZombie_Refugee3 : zZombie_Base {
+		scope = protected;
+		model = "\breakingpoint_classes\models\BP_Refugee3.p3d";
+		hiddenSelections[] = {};
+		hiddenSelectionsTextures[] = {};
+		identityTypes[] = {"BP_Zombie2"};
 	};
-	class BPZombie_Refugee1: zZombie_Base
-	{
-		scope=1;
-		model="\breakingpoint_classes\models\BP_Refugee1.p3d";
-		hiddenSelections[]=
-		{
-			"Camo"
-		};
-		hiddenSelectionsTextures[]=
-		{
-			"breakingpoint_classes\textures\overall_co.paa"
-		};
-		identityTypes[]=
-		{
-			"BP_Zombie1"
-		};
+	class BPZombie_Hunter1 : zZombie_Base {
+		scope = protected;
+		model = "\breakingpoint_classes\models\BP_Hunter1.p3d";
+		hiddenSelections[] = {"Camo1"};
+		hiddenSelectionsTextures[] = {"breakingpoint_classes\textures\acr_soldier_nic_co.paa"};
+		identityTypes[] = {"BP_Zombie1"};
 	};
-	class BPZombie_Refugee2: zZombie_Base
-	{
-		scope=1;
-		model="\breakingpoint_classes\models\BP_Refugee2.p3d";
-		hiddenSelections[]=
-		{
-			"Camo"
-		};
-		hiddenSelectionsTextures[]=
-		{
-			"breakingpoint\textures\clothing\worker_co.paa"
-		};
-		identityTypes[]=
-		{
-			"BP_Zombie1"
-		};
+	class BPZombie_Hunter2 : zZombie_Base {
+		scope = protected;
+		model = "\breakingpoint_classes\models\BP_Hunter2.p3d";
+		hiddenSelections[] = {"Camo1"};
+		hiddenSelectionsTextures[] = {"breakingpoint_classes\textures\acr_soldier_nic_co.paa"};
+		identityTypes[] = {"BP_Zombie1"};
 	};
-	class BPZombie_Refugee3: zZombie_Base
-	{
-		scope=1;
-		model="\breakingpoint_classes\models\BP_Refugee3.p3d";
-		hiddenSelections[]={};
-		hiddenSelectionsTextures[]={};
-		identityTypes[]=
-		{
-			"BP_Zombie2"
-		};
-	};
-	class BPZombie_Hunter1: zZombie_Base
-	{
-		scope=1;
-		model="\breakingpoint_classes\models\BP_Hunter1.p3d";
-		hiddenSelections[]=
-		{
-			"Camo1"
-		};
-		hiddenSelectionsTextures[]=
-		{
-			"breakingpoint_classes\textures\acr_soldier_nic_co.paa"
-		};
-		identityTypes[]=
-		{
-			"BP_Zombie1"
-		};
-	};
-	class BPZombie_Hunter2: zZombie_Base
-	{
-		scope=1;
-		model="\breakingpoint_classes\models\BP_Hunter2.p3d";
-		hiddenSelections[]=
-		{
-			"Camo1"
-		};
-		hiddenSelectionsTextures[]=
-		{
-			"breakingpoint_classes\textures\acr_soldier_nic_co.paa"
-		};
-		identityTypes[]=
-		{
-			"BP_Zombie1"
-		};
-	};
-	class BPZombie_Hunter3: zZombie_Base
-	{
-		scope=1;
-		model="\breakingpoint_classes\models\BP_Hunter3.p3d";
-		hiddenSelections[]=
-		{
-			"Camo1"
-		};
-		hiddenSelectionsTextures[]=
-		{
-			"breakingpoint_classes\textures\acr_soldier_nic_co.paa"
-		};
-		identityTypes[]=
-		{
-			"BP_Zombie2"
-		};
+	class BPZombie_Hunter3 : zZombie_Base {
+		scope = protected;
+		model = "\breakingpoint_classes\models\BP_Hunter3.p3d";
+		hiddenSelections[] = {"Camo1"};
+		hiddenSelectionsTextures[] = {"breakingpoint_classes\textures\acr_soldier_nic_co.paa"};
+		identityTypes[] = {"BP_Zombie2"};
 	};
 	class BPZombie_RebelImp1: zZombie_Imp
 	{

--- a/ModSource/breakingpoint_infected/CfgVehicles.hpp
+++ b/ModSource/breakingpoint_infected/CfgVehicles.hpp
@@ -26,6 +26,11 @@ class CfgVehicles
 	class CAManBase;
 	class zZombie_Base : CAManBase 
 	{
+		armor = 360; // total hit points (meaning global "health") of the object.
+		armorStructural = 0.4; // divides all damage taken to total hit point, either directly or through hit point passThrough coefficient. must be adjusted for each model to achieve consistent total damage results
+		explosionShielding = 0.04; // for consistent explosive damage after adjusting = ( armorStructural / 10 )
+		minTotalDamageThreshold	= 0.001; // minimalHit for total damage
+		impactDamageMultiplier = 0.5; // multiplier for falling damage
 		scope = private;
 		side = EAST;
 		modelSides[] = {NO_SIDE, EAST, WEST, CIVILIAN};
@@ -126,31 +131,47 @@ class CfgVehicles
 		
 		//Hit Points / Damage
 		class HitPoints {
-			class HitHead {
-				armor = 0.3;
-				material = -1;
-				name = "head_hit";
-				passThrough = true;
-				memoryPoint = "pilot";
+			class HitHead
+			{
+				armor = 3.30000001;
+				material=-1;
+				minimalHit = 0.001;
+				passThrough = 0.01;
+				radius = 0.01;
+				name="head_hit";
+				//passThrough="true";
+				memoryPoint="pilot";
 			};
 			
-			class HitBody : HitHead {
-				armor = 2;
-				name = "body";
-				memoryPoint = "aimPoint";
+			class HitBody: HitHead
+			{
+				armor = 50;
+				minimalHit = 10;
+				passThrough = 0.001;
+				radius = 0.01;
+				name="body";
+				memoryPoint="aimPoint";
 			};
 			
-			class HitSpine : HitHead {
-				armor = 2;
-				name = "Spine2";
-				memoryPoint = "aimPoint";
+			class HitSpine: HitHead
+			{
+				armor = 50;
+				minimalHit = 10;
+				passThrough = 0.001;
+				radius = 0.01;
+				name="Spine2";
+				memoryPoint="aimPoint";
 			};
 			
-			class HitHands : HitHead {
-				armor = 0.5;
-				material = -1;
-				name = "hands";
-				passThrough = true;
+			class HitHands: HitHead
+			{
+				armor = 50.5;
+				minimalHit = 25;
+				passThrough = 0.001;
+				radius = 0.01;
+				material=-1;
+				name="hands";
+				//passThrough="true";
 			};
 			
 			class HitLArm : HitHands {

--- a/ModSource/breakingpoint_server/config.cpp
+++ b/ModSource/breakingpoint_server/config.cpp
@@ -58,6 +58,10 @@ class CfgBreakingPointServerSettings
 	{
 		medicalCooldown = 900;	//time in seconds for point gain on medical assistance
 	};
+	class HardcoreZombies
+	{
+		enableHardcoreZombies=0;
+	};
 };
 
 class CfgDifficultyPresets

--- a/ModSource/breakingpoint_server/config.cpp
+++ b/ModSource/breakingpoint_server/config.cpp
@@ -58,10 +58,6 @@ class CfgBreakingPointServerSettings
 	{
 		medicalCooldown = 900;	//time in seconds for point gain on medical assistance
 	};
-	class HardcoreZombies
-	{
-		enableHardcoreZombies=0;
-	};
 };
 
 class CfgDifficultyPresets

--- a/ModSource/breakingpoint_weapons_cfg/config.cpp
+++ b/ModSource/breakingpoint_weapons_cfg/config.cpp
@@ -18034,7 +18034,7 @@ class BP_arifle_AKS_base_F : arifle_AKS_base_F { //AKS-74U Base
 		bullet12[] = {"A3\sounds_f\weapons\shells\7_62\grass_762_04", 0.707946, 1, 45};
 		soundBullet[] = {"bullet1", 0.083000, "bullet2", 0.083000, "bullet3", 0.083000, "bullet4", 0.083000, "bullet5", 0.083000, "bullet6", 0.083000, "bullet7", 0.083000, "bullet8", 0.083000, "bullet9", 0.083000, "bullet10", 0.083000, "bullet11", 0.083000, "bullet12", 0.083000};
 		initSpeed = -1.04;
-		recoil = "recoil_ebr";
+		recoil = "recoil_mxm";
 		inertia = 0.33500;
 		modes[] = {"Single"};		
 		class Single : Mode_SemiAuto 
@@ -18423,7 +18423,7 @@ class BP_arifle_AKS_base_F : arifle_AKS_base_F { //AKS-74U Base
 			reloadTime = 0.085000;
 			//recoil = "recoil_single_ebr";
 			//recoilProne = "recoil_single_prone_ebr";
-			dispersion = 0.000977;
+			dispersion = 0.000777;
 			minRange = 2;
 			minRangeProbab = 1.000000;
 			midRange = 250;
@@ -22218,7 +22218,7 @@ class CfgMagazines {
 		ammo = "BP_93x64_Ball";
 		count = 10;
 		mass = 18;
-		initSpeed = 762;
+		initSpeed = 719;
 		tracersEvery = 0;
 		lastRoundsTracer = 0;
 		descriptionShort = "10Rnd 9.3x64mmR magazine";
@@ -26655,16 +26655,16 @@ class CfgAmmo {
 
     class BP_93x64_Ball: BulletBase 
 	{
-		hit = 33.07;
+		hit = 26;
 		cartridge = "FxCartridge_762";
 		visibleFire = 22;
 		audibleFire = 55;
 		simulationStep = 0.10;
 		visibleFireTime = 3;
-		typicalSpeed = 762;
-		caliber = 3.410000;
+		typicalSpeed = 719;
+		caliber = 1.970000;
 		legFracture = true;
-		airFriction = -0.001175;
+		airFriction = -0.000925;
 		muzzleEffect = "BIS_Effects_HeavySniper";
 		class Medical
 		{
@@ -26694,14 +26694,14 @@ class CfgAmmo {
 		};		
 		class CamShakeFire 
 		{
-			power = 4;
+			power = 2;
 			duration = 0.500000;
 			frequency = 20;
 			distance = 10;
 		};
 		class CamShakeHit 
 		{
-			power = 14;
+			power = 7;
 			duration = 1;
 			frequency = 20;
 		};
@@ -26709,15 +26709,15 @@ class CfgAmmo {
 
 	class BP_93x64_OVPBall: BulletBase 
 	{
-		hit = 33.07;
+		hit = 27.5;
 		cartridge = "FxCartridge_762";
 		visibleFire = 22;
 		audibleFire = 55;
 		visibleFireTime = 3;
 		typicalSpeed = 785;
-		caliber = 3.410000;
+		caliber = 2.170000;
 		legFracture = true;
-		airFriction = -0.001175;
+		airFriction = -0.000925;
 		muzzleEffect = "BIS_Effects_HeavySniper";
 		class Medical
 		{
@@ -26754,7 +26754,7 @@ class CfgAmmo {
 		};
 		class CamShakeHit 
 		{
-			power = 14;
+			power = 7;
 			duration = 1;
 			frequency = 20;
 		};
@@ -26999,12 +26999,12 @@ class CfgAmmo {
 		cartridge = "FxCartridge_127";
 		typicalSpeed = 883;
 		simulationStep = 0.12;
-		//indirectHit = 20;
-		//indirectHitRange = 0.500000;
+		indirectHit = 20;
+		indirectHitRange = 0.500000;
 		audibleFire = 45;
 		visibleFire = 10;
 		airFriction = -0.00056;
-		caliber = 3.100000;
+		caliber = 2.700000;
 		legFracture = true;
 		muzzleEffect = "BIS_Effects_HeavySniper";
 		supersonicCrackNear[] = {"\breakingpoint_jsrs\sounds\B_762x51_Ball", 0.424813, 1, 50};
@@ -27109,7 +27109,7 @@ class CfgAmmo {
 	
 	class BP_300_WinMag: B_762x51_Ball  
 	{
-	    hit = 26.19;
+	    hit = 22.65;
 		typicalSpeed = 874;
 		indirectHit = 0;
 		indirectHitRange = 0.000000;
@@ -27205,7 +27205,7 @@ class CfgAmmo {
 	
 	class BP_300M_WinMag: B_408_Ball  
 	{
-	    hit = 28.95;
+	    hit = 24.75;
 		cartridge = "FxCartridge_127";
 		typicalSpeed = 993;
 		simulationStep = 0.12;

--- a/ModSource/breakingpoint_weapons_cfg/config.cpp
+++ b/ModSource/breakingpoint_weapons_cfg/config.cpp
@@ -18034,7 +18034,7 @@ class BP_arifle_AKS_base_F : arifle_AKS_base_F { //AKS-74U Base
 		bullet12[] = {"A3\sounds_f\weapons\shells\7_62\grass_762_04", 0.707946, 1, 45};
 		soundBullet[] = {"bullet1", 0.083000, "bullet2", 0.083000, "bullet3", 0.083000, "bullet4", 0.083000, "bullet5", 0.083000, "bullet6", 0.083000, "bullet7", 0.083000, "bullet8", 0.083000, "bullet9", 0.083000, "bullet10", 0.083000, "bullet11", 0.083000, "bullet12", 0.083000};
 		initSpeed = -1.04;
-		recoil = "recoil_mxm";
+		recoil = "recoil_ebr";
 		inertia = 0.33500;
 		modes[] = {"Single"};		
 		class Single : Mode_SemiAuto 
@@ -18423,7 +18423,7 @@ class BP_arifle_AKS_base_F : arifle_AKS_base_F { //AKS-74U Base
 			reloadTime = 0.085000;
 			//recoil = "recoil_single_ebr";
 			//recoilProne = "recoil_single_prone_ebr";
-			dispersion = 0.000777;
+			dispersion = 0.000977;
 			minRange = 2;
 			minRangeProbab = 1.000000;
 			midRange = 250;
@@ -22218,7 +22218,7 @@ class CfgMagazines {
 		ammo = "BP_93x64_Ball";
 		count = 10;
 		mass = 18;
-		initSpeed = 719;
+		initSpeed = 762;
 		tracersEvery = 0;
 		lastRoundsTracer = 0;
 		descriptionShort = "10Rnd 9.3x64mmR magazine";
@@ -26655,16 +26655,16 @@ class CfgAmmo {
 
     class BP_93x64_Ball: BulletBase 
 	{
-		hit = 26;
+		hit = 33.07;
 		cartridge = "FxCartridge_762";
 		visibleFire = 22;
 		audibleFire = 55;
 		simulationStep = 0.10;
 		visibleFireTime = 3;
-		typicalSpeed = 719;
-		caliber = 1.970000;
+		typicalSpeed = 762;
+		caliber = 3.410000;
 		legFracture = true;
-		airFriction = -0.000925;
+		airFriction = -0.001175;
 		muzzleEffect = "BIS_Effects_HeavySniper";
 		class Medical
 		{
@@ -26694,14 +26694,14 @@ class CfgAmmo {
 		};		
 		class CamShakeFire 
 		{
-			power = 2;
+			power = 4;
 			duration = 0.500000;
 			frequency = 20;
 			distance = 10;
 		};
 		class CamShakeHit 
 		{
-			power = 7;
+			power = 14;
 			duration = 1;
 			frequency = 20;
 		};
@@ -26709,15 +26709,15 @@ class CfgAmmo {
 
 	class BP_93x64_OVPBall: BulletBase 
 	{
-		hit = 27.5;
+		hit = 33.07;
 		cartridge = "FxCartridge_762";
 		visibleFire = 22;
 		audibleFire = 55;
 		visibleFireTime = 3;
 		typicalSpeed = 785;
-		caliber = 2.170000;
+		caliber = 3.410000;
 		legFracture = true;
-		airFriction = -0.000925;
+		airFriction = -0.001175;
 		muzzleEffect = "BIS_Effects_HeavySniper";
 		class Medical
 		{
@@ -26754,7 +26754,7 @@ class CfgAmmo {
 		};
 		class CamShakeHit 
 		{
-			power = 7;
+			power = 14;
 			duration = 1;
 			frequency = 20;
 		};
@@ -26999,12 +26999,12 @@ class CfgAmmo {
 		cartridge = "FxCartridge_127";
 		typicalSpeed = 883;
 		simulationStep = 0.12;
-		indirectHit = 20;
-		indirectHitRange = 0.500000;
+		//indirectHit = 20;
+		//indirectHitRange = 0.500000;
 		audibleFire = 45;
 		visibleFire = 10;
 		airFriction = -0.00056;
-		caliber = 2.700000;
+		caliber = 3.100000;
 		legFracture = true;
 		muzzleEffect = "BIS_Effects_HeavySniper";
 		supersonicCrackNear[] = {"\breakingpoint_jsrs\sounds\B_762x51_Ball", 0.424813, 1, 50};
@@ -27055,9 +27055,9 @@ class CfgAmmo {
 	    hit = 55;
 		cartridge = "FxCartridge_127";
 		typicalSpeed = 995;
-		indirectHit = 15;
+		//indirectHit = 15;
 		simulationStep = 0.09;
-		indirectHitRange = 0.400000;
+		//indirectHitRange = 0.400000;
 		audibleFire = 47;
 		visibleFire = 10;
 		airFriction = -0.00056;
@@ -27109,7 +27109,7 @@ class CfgAmmo {
 	
 	class BP_300_WinMag: B_762x51_Ball  
 	{
-	    hit = 22.65;
+	    hit = 26.19;
 		typicalSpeed = 874;
 		indirectHit = 0;
 		indirectHitRange = 0.000000;
@@ -27205,7 +27205,7 @@ class CfgAmmo {
 	
 	class BP_300M_WinMag: B_408_Ball  
 	{
-	    hit = 24.75;
+	    hit = 28.95;
 		cartridge = "FxCartridge_127";
 		typicalSpeed = 993;
 		simulationStep = 0.12;

--- a/ModSource/breakingpoint_weapons_cfg/config.cpp
+++ b/ModSource/breakingpoint_weapons_cfg/config.cpp
@@ -27055,9 +27055,9 @@ class CfgAmmo {
 	    hit = 55;
 		cartridge = "FxCartridge_127";
 		typicalSpeed = 995;
-		//indirectHit = 15;
+		indirectHit = 15;
 		simulationStep = 0.09;
-		//indirectHitRange = 0.400000;
+		indirectHitRange = 0.400000;
 		audibleFire = 47;
 		visibleFire = 10;
 		airFriction = -0.00056;


### PR DESCRIPTION
Option to replace vanilla zombies with hardcore zombies via loottable.

- By default, vanilla zombies are spawned. Loot table needs to be custom and edited in order for hardcore zeds to spawn
- Hardcore Zeds can only be one-shot in the head. Body and other parts can take some damage before zed dies.
- Hardcore zed runspeed increase. Big boost on zed sprint. Walk speed was increased a bit in order for animation&gameplay to look more natural.

Slow and easy killable zombies were providing no threat and gameplay-wise were useless.
Cities/Military areas shall provide a threat always, even if no players are around.
Stronger zombies help to make it happen.