### PR TITLE
Revert "Autorun fixes"

### DIFF
--- a/ModSource/breakingpoint_client/functions/GUI/fn_spaceInterrupt.sqf
+++ b/ModSource/breakingpoint_client/functions/GUI/fn_spaceInterrupt.sqf
@@ -643,6 +643,9 @@ if (_dikCode in actionKeys "User8") then {
 };
 */
 
+_terrainGradientMaxIncline = 30;
+_terrainGradientMaxDecline = -30;
+
 if (_dikCode in actionKeys "User9") then 
 {
 	if (BP_isUndead) exitWith {};
@@ -677,24 +680,20 @@ if (_dikCode in actionKeys "User9") then
 					//No Resting While Autorunning
 					if (r_action_rest) then { r_action_rest = false; };
 					
+					//No Autorun on steep gradients.
+					_gradient = player call BP_fnc_getTerrainGradient;
+					if (_gradient > 30) exitWith {true};
+					if (_gradient < -30) exitWith {true};
+					
 					//No Autorun While Hostage
 					if (player getVariable ["med_hostage",false]) exitWith {true};
 					
 					//Don't Autorun While TranQ
 					if (r_player_unconscious) exitWith {true};
 					
-					//Autorun speed depends on terrain gradient
-					_gradient = player call BP_fnc_getTerrainGradient;
-					if (_gradient <= 15 && _gradient >= -15) then {
-						player playActionNow "FastF";
-					} else {
-						if (_gradient >= 30 || _gradient <= -30) then {
-							player playActionNow "WalkF";
-						} else {
-							player playActionNow "SlowF";
-						};
-					};
-
+					//Play Animation
+					player playActionNow "FastF";
+					
 					//Delay
 					sleep 0.01;
 				


### PR DESCRIPTION
Reverts deathlyrage/breakingpointmod#104

Autorun still cancels on steep terrain.
Also, now autorun animation is broken on some maps. When you use it - running animation resets every ~second. You still continue to run but animation is very clunky.
Tested on Malden and Tembelan.