### PR TITLE
Added another house model to havenable buildings

### DIFF
--- a/ModSource/breakingpoint_client/functions/Init/fn_initVarsOnce.sqf
+++ b/ModSource/breakingpoint_client/functions/Init/fn_initVarsOnce.sqf
@@ -279,6 +279,7 @@ BP_Houses =
 	"Land_i_House_Big_01_V3_dam_F",
 	"Land_i_House_Big_01_V2_dam_F",
 	"Land_i_House_Big_01_V1_dam_F",
+	"Land_i_Stone_HouseSmall_V3_dam_F",
 	//Malden
 	"Land_i_House_Big_02_b_blue_F",
 	"Land_i_House_Big_02_b_pink_F",


### PR DESCRIPTION
Added one additional Altis-style house classname that spawns on Chernarus into the list of houses that can be turned into havens. This house model has been added to Chernarus but cannot be currently be made into a haven and we need all the havenable buildings we can get on Chernarus.