### PR TITLE
Revert "Revert "Autorun fixes (#104)" (#108)"

### DIFF
--- a/ModSource/breakingpoint_client/functions/GUI/fn_spaceInterrupt.sqf
+++ b/ModSource/breakingpoint_client/functions/GUI/fn_spaceInterrupt.sqf
@@ -643,9 +643,6 @@ if (_dikCode in actionKeys "User8") then {
 };
 */
 
-_terrainGradientMaxIncline = 30;
-_terrainGradientMaxDecline = -30;
-
 if (_dikCode in actionKeys "User9") then 
 {
 	if (BP_isUndead) exitWith {};
@@ -680,20 +677,24 @@ if (_dikCode in actionKeys "User9") then
 					//No Resting While Autorunning
 					if (r_action_rest) then { r_action_rest = false; };
 					
-					//No Autorun on steep gradients.
-					_gradient = player call BP_fnc_getTerrainGradient;
-					if (_gradient > 30) exitWith {true};
-					if (_gradient < -30) exitWith {true};
-					
 					//No Autorun While Hostage
 					if (player getVariable ["med_hostage",false]) exitWith {true};
 					
 					//Don't Autorun While TranQ
 					if (r_player_unconscious) exitWith {true};
 					
-					//Play Animation
-					player playActionNow "FastF";
-					
+					//Autorun speed depends on terrain gradient
+					_gradient = player call BP_fnc_getTerrainGradient;
+					if (_gradient <= 15 && _gradient >= -15) then {
+						player playActionNow "FastF";
+					} else {
+						if (_gradient >= 30 || _gradient <= -30) then {
+							player playActionNow "WalkF";
+						} else {
+							player playActionNow "SlowF";
+						};
+					};
+
 					//Delay
 					sleep 0.01;
 				


### PR DESCRIPTION
This reverts commit 77fdf74a0f3a087ee6f79c56bd9cab8d0e87e216.

Seems like it was either Arma3 update/other BP update/server update which sometimes had caused problems with autorun animation.
Apologies, the timing was right when the autorun fix was approved, so I've rushed conclusions on that one.

To be 100% sure I've installed these changes on my test server and tested it through. Works great. 
Apologies.