### PR TITLE
Fixed custom loot table

### DIFF
--- a/ModSource/breakingpoint_server/functions/Loot/fn_containerSpawnLoot.sqf
+++ b/ModSource/breakingpoint_server/functions/Loot/fn_containerSpawnLoot.sqf
@@ -18,7 +18,12 @@ _container setVariable ["lootItems",nil];
 _container setVariable ["lootType",nil];
 
 //Spawn In Loot
+//Mission config file loot table override.
 _config = 	configFile >> "CfgObjectLoot" >> _boxLootType;
+if (isClass (missionConfigFile >> "CfgObjectLoot" >> _boxLootType)) then
+{
+	_config = missionConfigFile >> "CfgObjectLoot" >> _boxLootType;
+};
 _itemTypes =	[] + getArray (_config >> "itemType");
 _cfgWeapons = configFile >> "CfgWeapons";
 


### PR DESCRIPTION
Custom loot table wasn't working correctly due to missing "CfgObjectLoot" class override.