### PR TITLE
 PSO-35 scope fix

### DIFF
--- a/ModSource/breakingpoint_weapons_cfg/config.cpp
+++ b/ModSource/breakingpoint_weapons_cfg/config.cpp
@@ -18483,7 +18483,7 @@ class BP_arifle_AKS_base_F : arifle_AKS_base_F { //AKS-74U Base
 			};
 		};
 		
-		linkedAttach[] = {"BP_PSOP"};
+		linkedAttach[] = {"BP_PSO35"};
 		chanceAttach[] = 
         {
 			{"BP_Harris",0.07},
@@ -19818,6 +19818,8 @@ class BP_arifle_AKS_base_F : arifle_AKS_base_F { //AKS-74U Base
 					opticsZoomMin = 0.07143;
 					opticsZoomMax = 0.07143;
 					opticsZoomInit = 0.07143;
+					discreteDistance[] = {100,200,300,400};
+					discreteDistanceInitIndex = 1;
 					distanceZoomMin = 100;
 					distanceZoomMax = 400;
 					memoryPointCamera = "opticView";
@@ -19831,11 +19833,11 @@ class BP_arifle_AKS_base_F : arifle_AKS_base_F { //AKS-74U Base
 					useModelOptics = 0;
 					opticsFlare = 0;
 					opticsDisablePeripherialVision = 0.5;
-					opticsZoomMin = 0.425000;
+					opticsZoomMin = 0.375000;
 					opticsZoomMax = 1.100000;
 					opticsZoomInit = 0.750000;
 					distanceZoomMin = 100;
-					distanceZoomMax = 200;
+					distanceZoomMax = 100;
 					memoryPointCamera = "eye";
 					visionMode[] = {};
 				};

--- a/ModSource/breakingpoint_weapons_cfg/config.cpp
+++ b/ModSource/breakingpoint_weapons_cfg/config.cpp
@@ -19818,7 +19818,7 @@ class BP_arifle_AKS_base_F : arifle_AKS_base_F { //AKS-74U Base
 					opticsZoomMin = 0.07143;
 					opticsZoomMax = 0.07143;
 					opticsZoomInit = 0.07143;
-					distanceZoomMin = 400;
+					distanceZoomMin = 100;
 					distanceZoomMax = 400;
 					memoryPointCamera = "opticView";
 					visionMode[] = {"Normal"};
@@ -19831,11 +19831,11 @@ class BP_arifle_AKS_base_F : arifle_AKS_base_F { //AKS-74U Base
 					useModelOptics = 0;
 					opticsFlare = 0;
 					opticsDisablePeripherialVision = 0.5;
-					opticsZoomMin = 0.250000;
+					opticsZoomMin = 0.425000;
 					opticsZoomMax = 1.100000;
-					opticsZoomInit = 0.250000;
-					distanceZoomMin = 400;
-					distanceZoomMax = 400;
+					opticsZoomInit = 0.750000;
+					distanceZoomMin = 100;
+					distanceZoomMax = 200;
 					memoryPointCamera = "eye";
 					visionMode[] = {};
 				};


### PR DESCRIPTION
Fixed and tuned pso35 scope discrede distances and zoom for optic sight and iron sights.
Changed scope attach for SVDK from PSOP to PSO35 as it better suits the gun's close to medium range firefight use and has working iron sights unlike PSOP&PSO-1 (will try to fix that later as it requires some digging into 3d modeling stuff).