### PR TITLE
Update config.cpp

### DIFF
--- a/ModSource/breakingpoint_map_chernarus/config.cpp
+++ b/ModSource/breakingpoint_map_chernarus/config.cpp
@@ -7435,14 +7435,6 @@ class CfgWorldList {
 	class Chernarus {};
 };
 
-class CfgMissions {
-	class Cutscenes {
-		class ChernarusIntro1 {
-			directory = "ca\chernarus\data\scenes\intro.Chernarus";
-		};
-	};
-};
-
 class CfgSurfaces {
 	class Default;	// External class reference
 	


### PR DESCRIPTION
This removes the intro from Chernaus, fixing the following error which always prompts when players leave Breaking Point Chernarus servers:

You cannot play/edit this mission; it is dependent on downloadable content that has bene deleted.cacharacters
ca_animals2_rabbit
CAWheeled3_TT650
cacharacters2
ca_missions_garbagecollector
ca_modules_functions
ca_animals2_wildboard
ca_animals2_dogs_pastor
ca_animals2_chicken
ca_animals2_cow
CAWheeled
ca_animals2_sheep