### PR TITLE
fixed 3.0 loot not working

### DIFF
--- a/ModSource/breakingpoint_code/Configs/CfgVehicles.hpp
+++ b/ModSource/breakingpoint_code/Configs/CfgVehicles.hpp
@@ -15,6 +15,13 @@ class CfgVehicles
 {
 	class Logic;
 	class VirtualMan_F;
+	class House_F;
+	class Land_House_Logic: House_F
+	{
+		scope=1;
+		armor=400;
+		model="\A3\Weapons_f\dummyweapon.p3d";
+	};
 	class BP_Player_Unit: VirtualMan_F
 	{
 		scope = 2;

--- a/ModSource/breakingpoint_code/Configs/CfgVehicles.hpp
+++ b/ModSource/breakingpoint_code/Configs/CfgVehicles.hpp
@@ -16,11 +16,28 @@ class CfgVehicles
 	class Logic;
 	class VirtualMan_F;
 	class House_F;
+	class House_Small_F: House_F{};
 	class Land_House_Logic: House_F
 	{
 		scope=1;
 		armor=400;
 		model="\A3\Weapons_f\dummyweapon.p3d";
+	};
+	class Land_FuelStation_Feed_F: House_Small_F
+	{
+		transportFuel=0;
+	};
+	class Land_fs_feed_F: House_Small_F
+	{
+		transportFuel=0;
+	};
+	class Land_A_FuelStation_Feed: House_Small_F
+	{
+		transportFuel=0;
+	};
+	class Land_Ind_FuelStation_Feed_EP1: House_Small_F
+	{
+		transportFuel=0;
 	};
 	class BP_Player_Unit: VirtualMan_F
 	{


### PR DESCRIPTION
when i removed old haven configs i also removed the house logic for the 3.0 loot, since it was in the CfgHavens.hpp file and i did not realize that

also fuel feed had auto refuel on, so i changed it to require fuelcans again

so i added that back thx to Bahlye for reporting that ;)